### PR TITLE
refactor: search関数のオーバーロード削除とシグネチャの簡素化

### DIFF
--- a/packages/annict-search/src/search.ts
+++ b/packages/annict-search/src/search.ts
@@ -17,23 +17,11 @@ function buildFullTitle(params: SearchParam): string {
 	return [params.workTitle, params.episodeTitle].filter(Boolean).join(" ");
 }
 
-export function search(
-	params: { title: string },
-	token: string,
-): Promise<SearchResult>;
-export function search(
-	params: { workTitle: string; episodeTitle: string },
-	token: string,
-): Promise<SearchResult>;
-export function search(
-	params: { workTitle: string; episodeNumber: string; episodeTitle: string },
-	token: string,
-): Promise<SearchResult>;
 export async function search(
 	params: SearchParam,
 	token: string,
 ): Promise<SearchResult> {
-	const target = "title" in params ? extract(params) : extract(params);
+	const target = extract(params);
 	const words = variants(target.workTitle);
 	const works = await searchWorks(words, token);
 

--- a/packages/annict-search/src/util/extract/extract.ts
+++ b/packages/annict-search/src/util/extract/extract.ts
@@ -16,22 +16,6 @@ function getMatch(
 	}
 }
 
-export function extract(params: { title: string }): {
-	workTitle: string;
-	episode: ExtractedEpisode | undefined;
-};
-export function extract(params: { workTitle: string; episodeTitle: string }): {
-	workTitle: string;
-	episode: ExtractedEpisode | undefined;
-};
-export function extract(params: {
-	workTitle: string;
-	episodeNumber: string;
-	episodeTitle: string;
-}): {
-	workTitle: string;
-	episode: ExtractedEpisode | undefined;
-};
 export function extract(params: SearchParam): {
 	workTitle: string;
 	episode: ExtractedEpisode | undefined;

--- a/packages/tasker/src/index.ts
+++ b/packages/tasker/src/index.ts
@@ -46,13 +46,7 @@ const main = async () => {
 		throw new Error("タイトルの取得に失敗しました。");
 	}
 
-	const result =
-		"title" in title
-			? await search({ title: title.title }, token)
-			: await search(
-					{ workTitle: title.workTitle, episodeTitle: title.episodeTitle },
-					token,
-				);
+	const result = await search(title, token);
 	if (!result) {
 		const titleStr =
 			"title" in title


### PR DESCRIPTION
## Summary
- search関数とextract関数のオーバーロード宣言を削除
- SearchParam型で統一し、型による分岐ロジックを簡略化

## 変更内容
- `packages/annict-search/src/search.ts`: 関数オーバーロードと不要な三項演算子を削除
- `packages/annict-search/src/util/extract/extract.ts`: 関数オーバーロードを削除
- `packages/tasker/src/index.ts`: 型による分岐ロジックを削除し、SearchParam型に統一