### PR TITLE
fix: annictパッケージへのimport文を更新

### DIFF
--- a/packages/extension/src/entrypoints/content/index.ts
+++ b/packages/extension/src/entrypoints/content/index.ts
@@ -1,4 +1,4 @@
-import { isRecorded, record } from "@anirec/annict-search";
+import { isRecorded, record } from "@anirec/annict";
 import type { ContentScriptContext } from "#imports";
 import { isPlayPage } from "@/utils/is-play-page";
 import {

--- a/packages/extension/src/entrypoints/content/search.ts
+++ b/packages/extension/src/entrypoints/content/search.ts
@@ -1,4 +1,4 @@
-import { type SearchResult, search } from "@anirec/annict-search";
+import { type SearchResult, search } from "@anirec/annict";
 import type { Title } from "@/types";
 
 export const searchFromList = async (

--- a/packages/tasker/src/index.ts
+++ b/packages/tasker/src/index.ts
@@ -1,4 +1,4 @@
-import { isRecorded, record, search } from "@anirec/annict-search";
+import { isRecorded, record, search } from "@anirec/annict";
 
 declare const annict_token: string;
 declare const nltext: string;


### PR DESCRIPTION
## 概要
前回のリファクタリング (#13) で漏れていたimport文を修正しました。

## 変更内容
以下のファイルで `@anirec/annict-search` から `@anirec/annict` へのimport更新を実施：
- `packages/extension/src/entrypoints/content/index.ts`
- `packages/extension/src/entrypoints/content/search.ts`
- `packages/tasker/src/index.ts`