### PR TITLE
feat: エピソードタイトルが numberText と一致する場合の検索に対応

### DIFF
--- a/packages/annict/src/fixture-test/fixtures/4645-76066__TVアニメ「orange」1LETTER01.json
+++ b/packages/annict/src/fixture-test/fixtures/4645-76066__TVアニメ「orange」1LETTER01.json
@@ -1,0 +1,191 @@
+{
+  "meta": {
+    "createdAt": "2026-03-06T11:03:39.848Z"
+  },
+  "input": {
+    "params": {
+      "title": "TVアニメ「orange」 1. LETTER01"
+    },
+    "annictUrl": "https://annict.com/works/4645/episodes/76066"
+  },
+  "expected": {
+    "id": "V29yay00NjQ1",
+    "title": "orange",
+    "episode": {
+      "id": "RXBpc29kZS03NjA2Ng==",
+      "number": 1,
+      "numberText": "LETTER01"
+    }
+  },
+  "variants": [
+    "TVアニメ「orange」",
+    "orange"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay03ODM1",
+      "title": "プラオレ！～PRIDE OF ORANGE～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMzY1OTE=",
+          "title": "face off",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzY3NDU=",
+          "title": "best friends",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzY4NzY=",
+          "title": "all for one",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzcwNzg=",
+          "title": "grinder",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzcxOTg=",
+          "title": "shoot out",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzczNDQ=",
+          "title": "debut",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc0OTY=",
+          "title": "cheer up!",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc2MjQ=",
+          "title": "accident",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc3NjU=",
+          "title": "awakening",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc5MDU=",
+          "title": "reunion",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzgxMDM=",
+          "title": "barn burner",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzgyMjQ=",
+          "title": "PRIDE OF ORANGE",
+          "number": 12,
+          "numberText": "第12話"
+        }
+      ],
+      "seriesList": []
+    },
+    {
+      "id": "V29yay00OTc0",
+      "title": "orange -未来-",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "orange"
+      ]
+    },
+    {
+      "id": "V29yay00NjQ1",
+      "title": "orange",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NjA2Ng==",
+          "number": 1,
+          "numberText": "LETTER01"
+        },
+        {
+          "id": "RXBpc29kZS03NjI1Ng==",
+          "number": 2,
+          "numberText": "LETTER02"
+        },
+        {
+          "id": "RXBpc29kZS03NjMwMw==",
+          "number": 3,
+          "numberText": "LETTER03"
+        },
+        {
+          "id": "RXBpc29kZS03NjQzOA==",
+          "number": 4,
+          "numberText": "LETTER04"
+        },
+        {
+          "id": "RXBpc29kZS03NjYxMA==",
+          "number": 5,
+          "numberText": "LETTER05"
+        },
+        {
+          "id": "RXBpc29kZS03NjcxMw==",
+          "number": 6,
+          "numberText": "LETTER06"
+        },
+        {
+          "id": "RXBpc29kZS03NjgzNg==",
+          "number": 7,
+          "numberText": "LETTER07"
+        },
+        {
+          "id": "RXBpc29kZS03NjkyOQ==",
+          "number": 8,
+          "numberText": "LETTER08"
+        },
+        {
+          "id": "RXBpc29kZS03NzAzMA==",
+          "number": 9,
+          "numberText": "LETTER09"
+        },
+        {
+          "id": "RXBpc29kZS03NzEyNQ==",
+          "number": 10,
+          "numberText": "LETTER10"
+        },
+        {
+          "id": "RXBpc29kZS03NzIyOA==",
+          "number": 11,
+          "numberText": "LETTER11"
+        },
+        {
+          "id": "RXBpc29kZS03NzMyNg==",
+          "number": 12,
+          "numberText": "LETTER12"
+        },
+        {
+          "id": "RXBpc29kZS03NzQyOQ==",
+          "title": "LAST LETTER",
+          "number": 13,
+          "numberText": "LETTER13"
+        }
+      ],
+      "seriesList": [
+        "orange"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/4645-76066__TVアニメ「orange」_1LETTER01.json
+++ b/packages/annict/src/fixture-test/fixtures/4645-76066__TVアニメ「orange」_1LETTER01.json
@@ -1,0 +1,192 @@
+{
+  "meta": {
+    "createdAt": "2026-03-06T11:06:26.215Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "TVアニメ「orange」",
+      "episodeTitle": "1. LETTER01"
+    },
+    "annictUrl": "https://annict.com/works/4645/episodes/76066"
+  },
+  "expected": {
+    "id": "V29yay00NjQ1",
+    "title": "orange",
+    "episode": {
+      "id": "RXBpc29kZS03NjA2Ng==",
+      "number": 1,
+      "numberText": "LETTER01"
+    }
+  },
+  "variants": [
+    "TVアニメ「orange」",
+    "orange"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay03ODM1",
+      "title": "プラオレ！～PRIDE OF ORANGE～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMzY1OTE=",
+          "title": "face off",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzY3NDU=",
+          "title": "best friends",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzY4NzY=",
+          "title": "all for one",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzcwNzg=",
+          "title": "grinder",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzcxOTg=",
+          "title": "shoot out",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzczNDQ=",
+          "title": "debut",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc0OTY=",
+          "title": "cheer up!",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc2MjQ=",
+          "title": "accident",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc3NjU=",
+          "title": "awakening",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc5MDU=",
+          "title": "reunion",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzgxMDM=",
+          "title": "barn burner",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzgyMjQ=",
+          "title": "PRIDE OF ORANGE",
+          "number": 12,
+          "numberText": "第12話"
+        }
+      ],
+      "seriesList": []
+    },
+    {
+      "id": "V29yay00OTc0",
+      "title": "orange -未来-",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "orange"
+      ]
+    },
+    {
+      "id": "V29yay00NjQ1",
+      "title": "orange",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NjA2Ng==",
+          "number": 1,
+          "numberText": "LETTER01"
+        },
+        {
+          "id": "RXBpc29kZS03NjI1Ng==",
+          "number": 2,
+          "numberText": "LETTER02"
+        },
+        {
+          "id": "RXBpc29kZS03NjMwMw==",
+          "number": 3,
+          "numberText": "LETTER03"
+        },
+        {
+          "id": "RXBpc29kZS03NjQzOA==",
+          "number": 4,
+          "numberText": "LETTER04"
+        },
+        {
+          "id": "RXBpc29kZS03NjYxMA==",
+          "number": 5,
+          "numberText": "LETTER05"
+        },
+        {
+          "id": "RXBpc29kZS03NjcxMw==",
+          "number": 6,
+          "numberText": "LETTER06"
+        },
+        {
+          "id": "RXBpc29kZS03NjgzNg==",
+          "number": 7,
+          "numberText": "LETTER07"
+        },
+        {
+          "id": "RXBpc29kZS03NjkyOQ==",
+          "number": 8,
+          "numberText": "LETTER08"
+        },
+        {
+          "id": "RXBpc29kZS03NzAzMA==",
+          "number": 9,
+          "numberText": "LETTER09"
+        },
+        {
+          "id": "RXBpc29kZS03NzEyNQ==",
+          "number": 10,
+          "numberText": "LETTER10"
+        },
+        {
+          "id": "RXBpc29kZS03NzIyOA==",
+          "number": 11,
+          "numberText": "LETTER11"
+        },
+        {
+          "id": "RXBpc29kZS03NzMyNg==",
+          "number": 12,
+          "numberText": "LETTER12"
+        },
+        {
+          "id": "RXBpc29kZS03NzQyOQ==",
+          "title": "LAST LETTER",
+          "number": 13,
+          "numberText": "LETTER13"
+        }
+      ],
+      "seriesList": [
+        "orange"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/4645-76066__TVアニメ「orange」_1_LETTER01.json
+++ b/packages/annict/src/fixture-test/fixtures/4645-76066__TVアニメ「orange」_1_LETTER01.json
@@ -1,0 +1,193 @@
+{
+  "meta": {
+    "createdAt": "2026-03-06T11:06:40.392Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "TVアニメ「orange」",
+      "episodeNumber": "1.",
+      "episodeTitle": "LETTER01"
+    },
+    "annictUrl": "https://annict.com/works/4645/episodes/76066"
+  },
+  "expected": {
+    "id": "V29yay00NjQ1",
+    "title": "orange",
+    "episode": {
+      "id": "RXBpc29kZS03NjA2Ng==",
+      "number": 1,
+      "numberText": "LETTER01"
+    }
+  },
+  "variants": [
+    "TVアニメ「orange」",
+    "orange"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay03ODM1",
+      "title": "プラオレ！～PRIDE OF ORANGE～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMzY1OTE=",
+          "title": "face off",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzY3NDU=",
+          "title": "best friends",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzY4NzY=",
+          "title": "all for one",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzcwNzg=",
+          "title": "grinder",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzcxOTg=",
+          "title": "shoot out",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzczNDQ=",
+          "title": "debut",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc0OTY=",
+          "title": "cheer up!",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc2MjQ=",
+          "title": "accident",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc3NjU=",
+          "title": "awakening",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzc5MDU=",
+          "title": "reunion",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzgxMDM=",
+          "title": "barn burner",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMzgyMjQ=",
+          "title": "PRIDE OF ORANGE",
+          "number": 12,
+          "numberText": "第12話"
+        }
+      ],
+      "seriesList": []
+    },
+    {
+      "id": "V29yay00OTc0",
+      "title": "orange -未来-",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "orange"
+      ]
+    },
+    {
+      "id": "V29yay00NjQ1",
+      "title": "orange",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NjA2Ng==",
+          "number": 1,
+          "numberText": "LETTER01"
+        },
+        {
+          "id": "RXBpc29kZS03NjI1Ng==",
+          "number": 2,
+          "numberText": "LETTER02"
+        },
+        {
+          "id": "RXBpc29kZS03NjMwMw==",
+          "number": 3,
+          "numberText": "LETTER03"
+        },
+        {
+          "id": "RXBpc29kZS03NjQzOA==",
+          "number": 4,
+          "numberText": "LETTER04"
+        },
+        {
+          "id": "RXBpc29kZS03NjYxMA==",
+          "number": 5,
+          "numberText": "LETTER05"
+        },
+        {
+          "id": "RXBpc29kZS03NjcxMw==",
+          "number": 6,
+          "numberText": "LETTER06"
+        },
+        {
+          "id": "RXBpc29kZS03NjgzNg==",
+          "number": 7,
+          "numberText": "LETTER07"
+        },
+        {
+          "id": "RXBpc29kZS03NjkyOQ==",
+          "number": 8,
+          "numberText": "LETTER08"
+        },
+        {
+          "id": "RXBpc29kZS03NzAzMA==",
+          "number": 9,
+          "numberText": "LETTER09"
+        },
+        {
+          "id": "RXBpc29kZS03NzEyNQ==",
+          "number": 10,
+          "numberText": "LETTER10"
+        },
+        {
+          "id": "RXBpc29kZS03NzIyOA==",
+          "number": 11,
+          "numberText": "LETTER11"
+        },
+        {
+          "id": "RXBpc29kZS03NzMyNg==",
+          "number": 12,
+          "numberText": "LETTER12"
+        },
+        {
+          "id": "RXBpc29kZS03NzQyOQ==",
+          "title": "LAST LETTER",
+          "number": 13,
+          "numberText": "LETTER13"
+        }
+      ],
+      "seriesList": [
+        "orange"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/search.ts
+++ b/packages/annict/src/search.ts
@@ -8,6 +8,7 @@ import {
   findEpisodeByNumberText,
   findEpisodeByTitle,
   findEpisodeByTitleAndNumberText,
+  findEpisodeByTitleAsNumberText,
 } from "./util/search/find-episode";
 import { variants } from "./util/search/variants";
 
@@ -84,7 +85,8 @@ export async function search(
     // title or numberText が一致するエピソードを探す
     const episode =
       findEpisodeByTitle(work.episodes, target.episode) ??
-      findEpisodeByNumberText(work.episodes, target.episode);
+      findEpisodeByNumberText(work.episodes, target.episode) ??
+      findEpisodeByTitleAsNumberText(work.episodes, target.episode);
     if (episode) {
       return {
         id: work.id,
@@ -107,7 +109,8 @@ export async function search(
     if (weakMatchWork.episodes && target.episode) {
       const episode =
         findEpisodeByTitle(weakMatchWork.episodes, target.episode) ??
-        findEpisodeByNumberText(weakMatchWork.episodes, target.episode);
+        findEpisodeByNumberText(weakMatchWork.episodes, target.episode) ??
+        findEpisodeByTitleAsNumberText(weakMatchWork.episodes, target.episode);
       if (episode) {
         return { id: weakMatchWork.id, title: weakMatchWork.title, episode };
       }

--- a/packages/annict/src/util/search/find-episode.test.ts
+++ b/packages/annict/src/util/search/find-episode.test.ts
@@ -4,6 +4,7 @@ import {
   findEpisodeByNumberText,
   findEpisodeByTitle,
   findEpisodeByTitleAndNumberText,
+  findEpisodeByTitleAsNumberText,
 } from "./find-episode";
 
 const episodes = [
@@ -401,6 +402,67 @@ describe("findEpisodeByTitleAndNumberText", () => {
       number: undefined,
     };
     expect(findEpisodeByTitleAndNumberText(ambiguous, target)?.id).toEqual(
+      undefined,
+    );
+  });
+});
+
+describe("findEpisodeByTitleAsNumberText", () => {
+  test("target.titleがep.numberTextにstrictで一致する場合に返す", () => {
+    const target = {
+      title: "第一回",
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(findEpisodeByTitleAsNumberText(episodes, target)?.id).toEqual(
+      "RXBpc29kZS0xODM1Mg==",
+    );
+  });
+
+  test("strictでは一致しないがweakで1件一致する場合に返す", () => {
+    // ！があるのでstrictでは不一致、weakで記号を除去して一致
+    const target = {
+      title: "第一回！",
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(findEpisodeByTitleAsNumberText(episodes, target)?.id).toEqual(
+      "RXBpc29kZS0xODM1Mg==",
+    );
+  });
+
+  test("weakで複数一致する場合はundefinedを返す", () => {
+    const ambiguous = [
+      { id: "ep1", title: "タイトルA", number: 1, numberText: "第一回！" },
+      { id: "ep2", title: "タイトルB", number: 2, numberText: "第一回？" },
+    ];
+    const target = {
+      title: "第一回",
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(findEpisodeByTitleAsNumberText(ambiguous, target)?.id).toEqual(
+      undefined,
+    );
+  });
+
+  test("target.titleがundefinedの場合はundefinedを返す", () => {
+    const target = { title: undefined, numberText: "第一回", number: 1 };
+    expect(findEpisodeByTitleAsNumberText(episodes, target)?.id).toEqual(
+      undefined,
+    );
+  });
+
+  test("ep.numberTextがundefinedのエピソードはスキップする", () => {
+    const noNumberText = [
+      { id: "ep1", title: "タイトルA", number: 1, numberText: undefined },
+    ];
+    const target = {
+      title: "タイトルA",
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(findEpisodeByTitleAsNumberText(noNumberText, target)?.id).toEqual(
       undefined,
     );
   });

--- a/packages/annict/src/util/search/find-episode.ts
+++ b/packages/annict/src/util/search/find-episode.ts
@@ -76,6 +76,19 @@ export function findEpisodeByTitleAndNumberText(
   );
 }
 
+// target.title が ep.numberText と一致するエピソード
+export function findEpisodeByTitleAsNumberText(
+  episodes: Episode[],
+  target: ExtractedEpisode,
+): Episode | undefined {
+  const title = target.title;
+  if (!title) return undefined;
+  return findWithStrictOrWeak(
+    episodes,
+    (ep, weak) => !!ep.numberText && isSameTitle(ep.numberText, title, weak),
+  );
+}
+
 // 「」内の文字列を抽出する
 function extractBracketContent(str: string): string | undefined {
   return str.match(/「([^」]+)」/)?.[1];


### PR DESCRIPTION
## Summary

- `findEpisodeByTitleAsNumberText` を追加し、`target.title` が `ep.numberText` と一致するエピソードを探せるようにした
- `search.ts` でタイトル・numberText による検索の後段にフォールバックとして追加
- `orange`（LETTER01形式のnumberTextを持つ作品）のフィクスチャテストを3パターン追加