### PR TITLE
feat: 汎用ロジックで対応できない作品のタイトルマッピング機能を追加

### DIFF
--- a/packages/annict/src/fixture-test/cli.ts
+++ b/packages/annict/src/fixture-test/cli.ts
@@ -5,6 +5,7 @@ import * as p from "@clack/prompts";
 import type { SearchParam } from "../types";
 import { fetchNode, searchWorks } from "../util/annict";
 import { extract } from "../util/extract/extract";
+import { applyMapping } from "../util/search/mapping";
 import { variants } from "../util/search/variants";
 import type { AnnictTarget, Expected, Fixture, ParamPattern } from "./types";
 
@@ -174,8 +175,8 @@ async function addFixture(
   const annictTarget = parseAnnictUrl(trimmedUrl);
 
   // variants, candidateWorks, expected を取得
-  const extracted = extract(trimmedParams);
-  const titleVariants = variants(extracted.workTitle);
+  const target = applyMapping(extract(trimmedParams));
+  const titleVariants = variants(target.workTitle);
   const candidateWorks = await searchWorks(titleVariants, token);
   const expected = await fetchExpected(annictTarget, token);
 

--- a/packages/annict/src/fixture-test/fixtures/2252-2803__〈物語〉シリーズセカンドシーズン_第1話_猫物語(白)第懇話『つばさタイガー其ノ壹』.json
+++ b/packages/annict/src/fixture-test/fixtures/2252-2803__〈物語〉シリーズセカンドシーズン_第1話_猫物語(白)第懇話『つばさタイガー其ノ壹』.json
@@ -1,0 +1,1383 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:26:02.673Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "〈物語〉シリーズ セカンドシーズン",
+      "episodeNumber": "第1話",
+      "episodeTitle": "猫物語(白) 第懇話『つばさタイガー其ノ壹』"
+    },
+    "annictUrl": "https://annict.com/works/2252/episodes/2803"
+  },
+  "expected": {
+    "id": "V29yay0yMjUy",
+    "title": "＜物語＞シリーズ セカンドシーズン",
+    "episode": {
+      "id": "RXBpc29kZS0yODAz",
+      "title": "猫物語(白) つばさタイガー 其ノ壹",
+      "numberText": "第懇話"
+    }
+  },
+  "variants": [
+    "＜物語＞シリーズ セカンドシーズン",
+    "<物語>シリーズ セカンドシーズン",
+    "セカンドシーズン"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0xMTg1",
+      "title": "D.C.S.S ～ダ・カーポ セカンドシーズン～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yMjkzNg==",
+          "title": "あれから２年…",
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzNw==",
+          "title": "読めない地図",
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzOA==",
+          "title": "ひとつ屋根の下",
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzOQ==",
+          "title": "桜並木の向こうに",
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0MA==",
+          "title": "魔法のしっぽ",
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0MQ==",
+          "title": "美春への手紙",
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Mg==",
+          "title": "すれ違い",
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Mw==",
+          "title": "嵐の予感",
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0NA==",
+          "title": "枯れない想い",
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0NQ==",
+          "title": "入部します！",
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Ng==",
+          "title": "ただいま執筆中！",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Nw==",
+          "title": "初音島のＷスター",
+          "numberText": "#12"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0OA==",
+          "title": "アイシアの夏",
+          "numberText": "#13"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0OQ==",
+          "title": "心の扉",
+          "numberText": "#14"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1MA==",
+          "title": "歌声を届けに",
+          "numberText": "#15"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1MQ==",
+          "title": "芽生えた想い",
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Mg==",
+          "title": "音夢と純一",
+          "numberText": "#17"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Mw==",
+          "title": "桜色の蜃気楼",
+          "numberText": "#18"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1NA==",
+          "title": "さくらの言葉",
+          "numberText": "#19"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1NQ==",
+          "title": "戻らない季節",
+          "numberText": "#20"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Ng==",
+          "title": "二人の魔法使い",
+          "numberText": "#21"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Nw==",
+          "title": "みんなの時間",
+          "numberText": "#22"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1OA==",
+          "title": "沈黙の夏",
+          "numberText": "#23"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1OQ==",
+          "title": "誓い",
+          "numberText": "#24"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk2MA==",
+          "title": "ダ・カーポ",
+          "numberText": "#25"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk2MQ==",
+          "title": "幸せの鐘",
+          "numberText": "#26"
+        }
+      ],
+      "seriesList": [
+        "D.C. ～ダ・カーポ～"
+      ]
+    },
+    {
+      "id": "V29yay01ODcw",
+      "title": "ハイキュー!! セカンドシーズン OAD「VS\"赤点\"」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ハイキュー!!"
+      ]
+    },
+    {
+      "id": "V29yay00OTE3",
+      "title": "魔法少女なんてもういいですから。セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NzU3OA==",
+          "title": "魔法少女になってメリットはあったの？",
+          "number": 1,
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS03NzcxNw==",
+          "title": "水着って変じゃないですか？",
+          "number": 2,
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS03NzkzMw==",
+          "title": "魔法少女ちや、登場ちやっ！",
+          "number": 3,
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS03OTgzNQ==",
+          "title": "一緒にゆずかを愛でませんか？",
+          "number": 4,
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS04MDI1NQ==",
+          "title": "お姉さんが何でも教えてあげるね",
+          "number": 5,
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS04MDQyNQ==",
+          "title": "だって、このままの格好じゃ…",
+          "number": 6,
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS04MDU0Nw==",
+          "title": "見え過ぎなんじゃないの？",
+          "number": 7,
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS04MDcyMQ==",
+          "title": "僕の話かい？",
+          "number": 8,
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS04MzI5OQ==",
+          "title": "私は働く！家族のために!!",
+          "number": 9,
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS04ODQ0Nw==",
+          "title": "海…ですか？",
+          "number": 10,
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS04ODYxMA==",
+          "title": "選ばれし者よ！いまこそ力を合わせて囚われのプリンセスを救うのじゃ～！",
+          "number": 11,
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS04ODc4MQ==",
+          "title": "魔法少女になってよかった事",
+          "number": 12,
+          "numberText": "#12"
+        }
+      ],
+      "seriesList": [
+        "魔法少女なんてもういいですから。"
+      ]
+    },
+    {
+      "id": "V29yay00ODg0",
+      "title": "12歳。～ちっちゃなムネのトキメキ～ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NzY2Nw==",
+          "title": "スキ・キス・キス!?",
+          "number": 13,
+          "numberText": "#13"
+        },
+        {
+          "id": "RXBpc29kZS03NzY3MA==",
+          "title": "ライバル",
+          "number": 14,
+          "numberText": "#14"
+        },
+        {
+          "id": "RXBpc29kZS03Nzg5MQ==",
+          "title": "ヤクソク",
+          "number": 15,
+          "numberText": "#15"
+        },
+        {
+          "id": "RXBpc29kZS03OTc5Nw==",
+          "title": "ココロ",
+          "number": 16,
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS04MDIyMw==",
+          "title": "アメアガリ",
+          "number": 17,
+          "numberText": "#17"
+        },
+        {
+          "id": "RXBpc29kZS04MDMzMA==",
+          "title": "バランス",
+          "number": 18,
+          "numberText": "#18"
+        },
+        {
+          "id": "RXBpc29kZS04MDUxMw==",
+          "title": "カタオモイ",
+          "number": 19,
+          "numberText": "#19"
+        },
+        {
+          "id": "RXBpc29kZS04MDY4NQ==",
+          "title": "オトナ",
+          "number": 20,
+          "numberText": "#20"
+        },
+        {
+          "id": "RXBpc29kZS04MTQ0OQ==",
+          "title": "シュウガクリョコウ",
+          "number": 21,
+          "numberText": "#21"
+        },
+        {
+          "id": "RXBpc29kZS04Nzk1OA==",
+          "title": "バイバイ",
+          "number": 22,
+          "numberText": "#22"
+        },
+        {
+          "id": "RXBpc29kZS04ODUyNg==",
+          "title": "エイエン",
+          "number": 23,
+          "numberText": "#23"
+        },
+        {
+          "id": "RXBpc29kZS04ODc0NA==",
+          "title": "ダイスキ",
+          "number": 24,
+          "numberText": "#24"
+        }
+      ],
+      "seriesList": [
+        "12歳。"
+      ]
+    },
+    {
+      "id": "V29yay01MTg2",
+      "title": "モンスターストライク セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMDA4ODM=",
+          "title": "前夜祭スペシャル「渇望の果ての理想郷」",
+          "number": 0,
+          "numberText": "第0話"
+        },
+        {
+          "id": "RXBpc29kZS05MDY5Ng==",
+          "title": "転校生は超絶級？",
+          "number": 0,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS05MDY5Nw==",
+          "title": "穢土に轟く忿怒の業拳",
+          "number": 0,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODQ=",
+          "title": "ワルプルギスの夜",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODU=",
+          "title": "焼き鳥・男気・冒険王",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODY=",
+          "title": "炸裂！セブンス・ギャラクシー",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODc=",
+          "title": "温泉、それは聖なる癒し",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODg=",
+          "title": "美人天使の湯けむり事件簿",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODk=",
+          "title": "斑目CEO",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTA=",
+          "title": "争いの無い世界",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTE=",
+          "title": "森羅万象の特異点",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTI=",
+          "title": "占い師も困惑！エナジーポイントは何処に？",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTM=",
+          "title": "恐怖の大王",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTQ=",
+          "title": "大予言者ノストラダムス",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTU=",
+          "title": "輪廻へ導く菩提樹の仙峡",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTY=",
+          "title": "それぞれの想い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTc=",
+          "title": "森の英雄 ロビン・フッド",
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTg=",
+          "title": "永久を夢む女神",
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTk=",
+          "title": "ツクヨミVSツクヨミ零",
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDA=",
+          "title": "女海賊アルビダの奮闘",
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDE=",
+          "title": "神殺しの提督ネイヴィス",
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDI=",
+          "title": "黒髭ティーチの企み",
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDM=",
+          "title": "媽祖の真実",
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDQ=",
+          "title": "最後の番人",
+          "numberText": "第23話"
+        }
+      ],
+      "seriesList": [
+        "モンスターストライク"
+      ]
+    },
+    {
+      "id": "V29yay0xMTgy",
+      "title": "D.C.II S.S. ～ダ・カーポII セカンドシーズン～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yNjMyNQ==",
+          "title": "深雪の如く",
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyNg==",
+          "title": "雪の密室",
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyNw==",
+          "title": "正義の魔法使い",
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyOA==",
+          "title": "幸せの形",
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyOQ==",
+          "title": "失望の雪原",
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMA==",
+          "title": "桜迷宮",
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMQ==",
+          "title": "変えられない夢",
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMg==",
+          "title": "さくらんぼとお兄ちゃん",
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMw==",
+          "title": "壊れゆく春",
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNA==",
+          "title": "夢の終わり",
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNQ==",
+          "title": "枯色の島",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNg==",
+          "title": "記憶の淵",
+          "numberText": "#12"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNw==",
+          "title": "巡りくる季節",
+          "numberText": "#13"
+        }
+      ],
+      "seriesList": [
+        "D.C. ～ダ・カーポ～"
+      ]
+    },
+    {
+      "id": "V29yay0xMDk3NQ==",
+      "title": "絆のアリル セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xNTMzNjI=",
+          "title": "～激戦のプレリュード～",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQwNTE=",
+          "title": "決意のデパーチャー",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQyNzM=",
+          "title": "私だけのザイル",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ1NzU=",
+          "title": "Answer",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ3MDc=",
+          "title": "片思いのライバル",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ5OTY=",
+          "title": "初めての感情",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTUyMjk=",
+          "title": "それぞれのソリチュード",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU0MzM=",
+          "title": "羽ばたきの行方",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU2MTQ=",
+          "title": "友情のシューズ",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU3NDg=",
+          "title": "未知数の私たち",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTYwNDc=",
+          "title": "絶望のタイムリミット",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTYyMzA=",
+          "title": "希望のコネクション",
+          "number": 24,
+          "numberText": "第24話"
+        }
+      ],
+      "seriesList": [
+        "絆のアリル"
+      ]
+    },
+    {
+      "id": "V29yay00MDky",
+      "title": "ヤマノススメ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS04NDE4",
+          "title": "テントに泊まろう！",
+          "number": 1,
+          "numberText": "新一合目"
+        },
+        {
+          "id": "RXBpc29kZS04NzUw",
+          "title": "富士山を見に行こう!!",
+          "number": 2,
+          "numberText": "新二合目"
+        },
+        {
+          "id": "RXBpc29kZS04ODc0",
+          "title": "山に登るということ",
+          "number": 3,
+          "numberText": "新三合目"
+        },
+        {
+          "id": "RXBpc29kZS05Mzk0",
+          "title": "降りた後のお楽しみ！",
+          "number": 4,
+          "numberText": "新四合目"
+        },
+        {
+          "id": "RXBpc29kZS05NjE1",
+          "title": "ゆるして、あげない！",
+          "number": 5,
+          "numberText": "新五合目"
+        },
+        {
+          "id": "RXBpc29kZS05ODY3",
+          "title": "好きな事をするために",
+          "number": 6,
+          "numberText": "新六合目"
+        },
+        {
+          "id": "RXBpc29kZS05OTA3OA==",
+          "title": "ブラノススメ？",
+          "number": 0,
+          "numberText": "六・五合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OA==",
+          "title": "カワノススメ？",
+          "number": 7,
+          "numberText": "新七合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQyNA==",
+          "title": "素敵な思い出を",
+          "number": 8,
+          "numberText": "新八合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDU1OA==",
+          "title": "初めまして、富士山",
+          "number": 9,
+          "numberText": "新九合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDgwNQ==",
+          "title": "富士山って、甘くない…",
+          "number": 10,
+          "numberText": "新十合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDg5Mw==",
+          "title": "もぉ、やだ!!",
+          "number": 11,
+          "numberText": "新十一合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMTExMw==",
+          "title": "Dear My Friend",
+          "number": 12,
+          "numberText": "新十二合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDA5NA==",
+          "title": "不思議なホタルの物語",
+          "number": 13,
+          "numberText": "新十三合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDE5Nw==",
+          "title": "お母さんと霧ヶ峰！",
+          "number": 14,
+          "numberText": "新十四合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDI5NQ==",
+          "title": "雨具の記憶～ねぇ、ゆうか。今なにしてるの？",
+          "number": 15,
+          "numberText": "新十五合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDM3Ng==",
+          "title": "思いをうけついで",
+          "number": 16,
+          "numberText": "新十六合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDQ2OA==",
+          "title": "高いところって、平気？",
+          "number": 17,
+          "numberText": "新十七合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDU2NA==",
+          "title": "アルバイト、始めます！",
+          "number": 18,
+          "numberText": "新十八合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDY2OA==",
+          "title": "宿題が終わらないよぉ",
+          "number": 19,
+          "numberText": "新十九合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDgxMw==",
+          "title": "ここなの飯能大冒険",
+          "number": 20,
+          "numberText": "新二十合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDk2Ng==",
+          "title": "思い出の山へ",
+          "number": 21,
+          "numberText": "新二十一合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTExMQ==",
+          "title": "ともだちになろ？",
+          "number": 22,
+          "numberText": "新二十二合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTIxMA==",
+          "title": "約束",
+          "number": 23,
+          "numberText": "新二十三合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTM0OA==",
+          "title": "さよなら、わたしたちの夏",
+          "number": 24,
+          "numberText": "新二十四合目"
+        },
+        {
+          "id": "RXBpc29kZS05OTA3OQ==",
+          "title": "ヤマノススメ・ベストテン！",
+          "number": 0,
+          "numberText": "いきなり百合目(笑)"
+        }
+      ],
+      "seriesList": [
+        "ヤマノススメ"
+      ]
+    },
+    {
+      "id": "V29yay01NTAw",
+      "title": "One Room セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMDEzNjI=",
+          "title": "花坂結衣のプロローグ",
+          "number": 0,
+          "numberText": "第0話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDE0MTg=",
+          "title": "花坂結衣ははしゃいでる",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDE1MjM=",
+          "title": "花坂結衣は叱られる",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMwMDM=",
+          "title": "花坂結衣は拗ねている",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMxMzI=",
+          "title": "花坂結衣はそばにいる",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMyMzY=",
+          "title": "七橋御乃梨は起こしに来る",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMzNjA=",
+          "title": "七橋御乃梨はしんみりする",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM0NjY=",
+          "title": "七橋御乃梨は無茶を言う",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM3MTI=",
+          "title": "七橋御乃梨はここにいる",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM4MDc=",
+          "title": "天月真白は探してる",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM5NjI=",
+          "title": "天月真白はやってみる",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQwODk=",
+          "title": "天月真白は思い出す",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQyNTY=",
+          "title": "天月真白は待っている",
+          "number": 12,
+          "numberText": "第12話"
+        }
+      ],
+      "seriesList": [
+        "One Room"
+      ]
+    },
+    {
+      "id": "V29yay0xMzY3MA==",
+      "title": "パディントンのぼうけん セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xNjA2Nzk=",
+          "title": "植物には愛を／アートってなあに？",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODA=",
+          "title": "ツリーハウスのお客様／パディントンのスパイ作戦",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODE=",
+          "title": "バースデーパーティーはむずかしい／パディントンのトレーニング",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODI=",
+          "title": "なつかしい味／最強カードをとりもどせ！",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODM=",
+          "title": "卓球はがんばらないでやろう！／思い出のスケート靴",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODQ=",
+          "title": "真夜中の侵入者／バードさんのロッキングチェアー",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODU=",
+          "title": "どっちに投票する？／小さな生き物のおうち",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODY=",
+          "title": "イモムシと新しい先生／夢の宇宙旅行",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODc=",
+          "title": "空想のゲーム／ラッキー！幸運をお願い",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODg=",
+          "title": "ものは捨てずにアップサイクル／農場の動物たちのおでかけ",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODk=",
+          "title": "カリーさんのブラックベリー？／ピザ作りをたのしもう！",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTA=",
+          "title": "お隣さんがやってきた／歯をなくしたジュディ",
+          "number": 12,
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTE=",
+          "title": "おしごとはマーマレードサンドのように／新聞記者、ウィンザーガーデンを走る！",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTI=",
+          "title": "親切は渡していくもの／お花の食べ物をつくろう",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTM=",
+          "title": "たえられない夏のおくりもの／お泊まり会はシンプルに",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTQ=",
+          "title": "生まれてはじめてのかんじゃさん／ミツバチはおともだち",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTU=",
+          "title": "新記録にちょうせん！／けっこんしきをもう一度",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTY=",
+          "title": "古いことはダメじゃない／パディントンと卵",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTc=",
+          "title": "カリーさんと森のたんけん／クマが高所恐怖症？",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTg=",
+          "title": "海賊からのメッセージ／グルーバーさんの決心",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTk=",
+          "title": "思いがけないクリスマス／ウィンザーガーデンパレードを止めるな！",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDA=",
+          "title": "どっちのしつじが いいしつじ？／いきがいだったラジオドラマ",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDE=",
+          "title": "ハロウィーンには幽霊がつきもの／ ペットショーの優勝者はだれ？",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDI=",
+          "title": "パディントン流ゴルフ攻略法／ペットホテルのお客さま",
+          "number": 24,
+          "numberText": "第24話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDM=",
+          "title": "なかよくなれない おとなりさん／みんなでおはなし、キャンプファイア",
+          "number": 25,
+          "numberText": "第25話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDQ=",
+          "title": "おうちを売らないで！／ハリネズミの大ぼうけん",
+          "number": 26,
+          "numberText": "第26話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDU=",
+          "title": "おたんじょうびのロンドンツアー　パート１／おたんじょうびのロンドンツアー　パート２",
+          "number": 27,
+          "numberText": "第27話"
+        }
+      ],
+      "seriesList": [
+        "パディントンのぼうけん"
+      ]
+    },
+    {
+      "id": "V29yay0yMjUy",
+      "title": "＜物語＞シリーズ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yODAz",
+          "title": "猫物語(白) つばさタイガー 其ノ壹",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA0",
+          "title": "猫物語(白) つばさタイガー 其ノ貳",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA1",
+          "title": "猫物語(白) つばさタイガー 其ノ參",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA2",
+          "title": "猫物語(白) つばさタイガー 其ノ肆",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA3",
+          "title": "猫物語(白) つばさタイガー 其ノ伍",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA4",
+          "title": "猫物語(黒) 総集篇I",
+          "numberText": "第禁話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA5",
+          "title": "傾物語 まよいキョンシー 其ノ壹",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEw",
+          "title": "傾物語 まよいキョンシー 其ノ貳",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEx",
+          "title": "傾物語 まよいキョンシー 其ノ參",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEy",
+          "title": "傾物語 まよいキョンシー 其ノ肆",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEz",
+          "title": "化物語 総集篇II",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yODE0",
+          "title": "囮物語 なでこメドゥーサ 其ノ壹",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE1",
+          "title": "囮物語 なでこメドゥーサ 其ノ貳",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE2",
+          "title": "囮物語 なでこメドゥーサ 其ノ參",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE3",
+          "title": "囮物語 なでこメドゥーサ 其ノ肆",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE4",
+          "title": "化物語&偽物語 総集篇III",
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS0yODE5",
+          "title": "鬼物語 しのぶタイム 其ノ壹",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIw",
+          "title": "鬼物語 しのぶタイム 其ノ貳",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIx",
+          "title": "鬼物語 しのぶタイム 其ノ參",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIy",
+          "title": "鬼物語 しのぶタイム 其ノ肆",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIz",
+          "title": "恋物語 ひたぎエンド 其ノ壹",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI0",
+          "title": "恋物語 ひたぎエンド 其ノ貳",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI1",
+          "title": "恋物語 ひたぎエンド 其ノ參",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI2",
+          "title": "恋物語 ひたぎエンド 其ノ肆",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI3",
+          "title": "恋物語 ひたぎエンド 其ノ伍",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI4",
+          "title": "恋物語 ひたぎエンド 其ノ陸",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2NA==",
+          "title": "花物語 するがデビル 其ノ壹",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2NQ==",
+          "title": "花物語 するがデビル 其ノ貳",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2Ng==",
+          "title": "花物語 するがデビル 其ノ參",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2Nw==",
+          "title": "花物語 するがデビル 其ノ肆",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2OA==",
+          "title": "花物語 するがデビル 其ノ伍",
+          "numberText": "第變話"
+        }
+      ],
+      "seriesList": [
+        "〈物語〉"
+      ]
+    },
+    {
+      "id": "V29yay00NDcx",
+      "title": "ハイキュー!! セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0zMjk0OA==",
+          "title": "レッツゴートーキョー!!",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0zOTM1OQ==",
+          "title": "直射日光",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS00NzI0NA==",
+          "title": "“村人B”",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS01ODY3OQ==",
+          "title": "“センターエース”",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS01ODgwMA==",
+          "title": "『欲』",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS01OTY1Nw==",
+          "title": "“テンポ”",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS01OTgwMg==",
+          "title": "月の出",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02MDIyNg==",
+          "title": "幻覚ヒーロー",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02MDQ5Mw==",
+          "title": "VS“傘”",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02MTY1NA==",
+          "title": "歯車",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02MTc5Nw==",
+          "title": "“上”",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02Mjc4OA==",
+          "title": "試合開始!!",
+          "number": 12,
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02MzE1Ng==",
+          "title": "シンプルで純粋な力",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQwMA==",
+          "title": "育ち盛り",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NjM3OA==",
+          "title": "アソビバ",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02ODEzNw==",
+          "title": "次へ",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS02ODc5Mw==",
+          "title": "根性無しの戦い",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS02OTU5OA==",
+          "title": "敗北者達",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS03MTgzNQ==",
+          "title": "鉄壁は何度でも築かれる",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS03MzAzMw==",
+          "title": "払拭",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS03MzE2Mw==",
+          "title": "壊し屋",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS03MzI2OA==",
+          "title": "元・根性無しの戦い",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS03MzQ0Ng==",
+          "title": "“チーム”",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS03MzUzOA==",
+          "title": "極限スイッチ",
+          "number": 24,
+          "numberText": "第24話"
+        },
+        {
+          "id": "RXBpc29kZS03MzkwMg==",
+          "title": "宣戦布告",
+          "number": 25,
+          "numberText": "第25話"
+        }
+      ],
+      "seriesList": [
+        "ハイキュー!!"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/2252-2803__〈物語〉シリーズセカンドシーズン_第1話猫物語(白)第懇話『つばさタイガー其ノ壹』.json
+++ b/packages/annict/src/fixture-test/fixtures/2252-2803__〈物語〉シリーズセカンドシーズン_第1話猫物語(白)第懇話『つばさタイガー其ノ壹』.json
@@ -1,0 +1,1382 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:25:21.565Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "〈物語〉シリーズ セカンドシーズン",
+      "episodeTitle": "第1話 猫物語(白) 第懇話『つばさタイガー其ノ壹』"
+    },
+    "annictUrl": "https://annict.com/works/2252/episodes/2803"
+  },
+  "expected": {
+    "id": "V29yay0yMjUy",
+    "title": "＜物語＞シリーズ セカンドシーズン",
+    "episode": {
+      "id": "RXBpc29kZS0yODAz",
+      "title": "猫物語(白) つばさタイガー 其ノ壹",
+      "numberText": "第懇話"
+    }
+  },
+  "variants": [
+    "＜物語＞シリーズ セカンドシーズン",
+    "<物語>シリーズ セカンドシーズン",
+    "セカンドシーズン"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0xMTg1",
+      "title": "D.C.S.S ～ダ・カーポ セカンドシーズン～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yMjkzNg==",
+          "title": "あれから２年…",
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzNw==",
+          "title": "読めない地図",
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzOA==",
+          "title": "ひとつ屋根の下",
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzOQ==",
+          "title": "桜並木の向こうに",
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0MA==",
+          "title": "魔法のしっぽ",
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0MQ==",
+          "title": "美春への手紙",
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Mg==",
+          "title": "すれ違い",
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Mw==",
+          "title": "嵐の予感",
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0NA==",
+          "title": "枯れない想い",
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0NQ==",
+          "title": "入部します！",
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Ng==",
+          "title": "ただいま執筆中！",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Nw==",
+          "title": "初音島のＷスター",
+          "numberText": "#12"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0OA==",
+          "title": "アイシアの夏",
+          "numberText": "#13"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0OQ==",
+          "title": "心の扉",
+          "numberText": "#14"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1MA==",
+          "title": "歌声を届けに",
+          "numberText": "#15"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1MQ==",
+          "title": "芽生えた想い",
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Mg==",
+          "title": "音夢と純一",
+          "numberText": "#17"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Mw==",
+          "title": "桜色の蜃気楼",
+          "numberText": "#18"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1NA==",
+          "title": "さくらの言葉",
+          "numberText": "#19"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1NQ==",
+          "title": "戻らない季節",
+          "numberText": "#20"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Ng==",
+          "title": "二人の魔法使い",
+          "numberText": "#21"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Nw==",
+          "title": "みんなの時間",
+          "numberText": "#22"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1OA==",
+          "title": "沈黙の夏",
+          "numberText": "#23"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1OQ==",
+          "title": "誓い",
+          "numberText": "#24"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk2MA==",
+          "title": "ダ・カーポ",
+          "numberText": "#25"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk2MQ==",
+          "title": "幸せの鐘",
+          "numberText": "#26"
+        }
+      ],
+      "seriesList": [
+        "D.C. ～ダ・カーポ～"
+      ]
+    },
+    {
+      "id": "V29yay01ODcw",
+      "title": "ハイキュー!! セカンドシーズン OAD「VS\"赤点\"」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ハイキュー!!"
+      ]
+    },
+    {
+      "id": "V29yay00OTE3",
+      "title": "魔法少女なんてもういいですから。セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NzU3OA==",
+          "title": "魔法少女になってメリットはあったの？",
+          "number": 1,
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS03NzcxNw==",
+          "title": "水着って変じゃないですか？",
+          "number": 2,
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS03NzkzMw==",
+          "title": "魔法少女ちや、登場ちやっ！",
+          "number": 3,
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS03OTgzNQ==",
+          "title": "一緒にゆずかを愛でませんか？",
+          "number": 4,
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS04MDI1NQ==",
+          "title": "お姉さんが何でも教えてあげるね",
+          "number": 5,
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS04MDQyNQ==",
+          "title": "だって、このままの格好じゃ…",
+          "number": 6,
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS04MDU0Nw==",
+          "title": "見え過ぎなんじゃないの？",
+          "number": 7,
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS04MDcyMQ==",
+          "title": "僕の話かい？",
+          "number": 8,
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS04MzI5OQ==",
+          "title": "私は働く！家族のために!!",
+          "number": 9,
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS04ODQ0Nw==",
+          "title": "海…ですか？",
+          "number": 10,
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS04ODYxMA==",
+          "title": "選ばれし者よ！いまこそ力を合わせて囚われのプリンセスを救うのじゃ～！",
+          "number": 11,
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS04ODc4MQ==",
+          "title": "魔法少女になってよかった事",
+          "number": 12,
+          "numberText": "#12"
+        }
+      ],
+      "seriesList": [
+        "魔法少女なんてもういいですから。"
+      ]
+    },
+    {
+      "id": "V29yay00ODg0",
+      "title": "12歳。～ちっちゃなムネのトキメキ～ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NzY2Nw==",
+          "title": "スキ・キス・キス!?",
+          "number": 13,
+          "numberText": "#13"
+        },
+        {
+          "id": "RXBpc29kZS03NzY3MA==",
+          "title": "ライバル",
+          "number": 14,
+          "numberText": "#14"
+        },
+        {
+          "id": "RXBpc29kZS03Nzg5MQ==",
+          "title": "ヤクソク",
+          "number": 15,
+          "numberText": "#15"
+        },
+        {
+          "id": "RXBpc29kZS03OTc5Nw==",
+          "title": "ココロ",
+          "number": 16,
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS04MDIyMw==",
+          "title": "アメアガリ",
+          "number": 17,
+          "numberText": "#17"
+        },
+        {
+          "id": "RXBpc29kZS04MDMzMA==",
+          "title": "バランス",
+          "number": 18,
+          "numberText": "#18"
+        },
+        {
+          "id": "RXBpc29kZS04MDUxMw==",
+          "title": "カタオモイ",
+          "number": 19,
+          "numberText": "#19"
+        },
+        {
+          "id": "RXBpc29kZS04MDY4NQ==",
+          "title": "オトナ",
+          "number": 20,
+          "numberText": "#20"
+        },
+        {
+          "id": "RXBpc29kZS04MTQ0OQ==",
+          "title": "シュウガクリョコウ",
+          "number": 21,
+          "numberText": "#21"
+        },
+        {
+          "id": "RXBpc29kZS04Nzk1OA==",
+          "title": "バイバイ",
+          "number": 22,
+          "numberText": "#22"
+        },
+        {
+          "id": "RXBpc29kZS04ODUyNg==",
+          "title": "エイエン",
+          "number": 23,
+          "numberText": "#23"
+        },
+        {
+          "id": "RXBpc29kZS04ODc0NA==",
+          "title": "ダイスキ",
+          "number": 24,
+          "numberText": "#24"
+        }
+      ],
+      "seriesList": [
+        "12歳。"
+      ]
+    },
+    {
+      "id": "V29yay01MTg2",
+      "title": "モンスターストライク セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMDA4ODM=",
+          "title": "前夜祭スペシャル「渇望の果ての理想郷」",
+          "number": 0,
+          "numberText": "第0話"
+        },
+        {
+          "id": "RXBpc29kZS05MDY5Ng==",
+          "title": "転校生は超絶級？",
+          "number": 0,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS05MDY5Nw==",
+          "title": "穢土に轟く忿怒の業拳",
+          "number": 0,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODQ=",
+          "title": "ワルプルギスの夜",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODU=",
+          "title": "焼き鳥・男気・冒険王",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODY=",
+          "title": "炸裂！セブンス・ギャラクシー",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODc=",
+          "title": "温泉、それは聖なる癒し",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODg=",
+          "title": "美人天使の湯けむり事件簿",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODk=",
+          "title": "斑目CEO",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTA=",
+          "title": "争いの無い世界",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTE=",
+          "title": "森羅万象の特異点",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTI=",
+          "title": "占い師も困惑！エナジーポイントは何処に？",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTM=",
+          "title": "恐怖の大王",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTQ=",
+          "title": "大予言者ノストラダムス",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTU=",
+          "title": "輪廻へ導く菩提樹の仙峡",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTY=",
+          "title": "それぞれの想い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTc=",
+          "title": "森の英雄 ロビン・フッド",
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTg=",
+          "title": "永久を夢む女神",
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTk=",
+          "title": "ツクヨミVSツクヨミ零",
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDA=",
+          "title": "女海賊アルビダの奮闘",
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDE=",
+          "title": "神殺しの提督ネイヴィス",
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDI=",
+          "title": "黒髭ティーチの企み",
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDM=",
+          "title": "媽祖の真実",
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDQ=",
+          "title": "最後の番人",
+          "numberText": "第23話"
+        }
+      ],
+      "seriesList": [
+        "モンスターストライク"
+      ]
+    },
+    {
+      "id": "V29yay0xMTgy",
+      "title": "D.C.II S.S. ～ダ・カーポII セカンドシーズン～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yNjMyNQ==",
+          "title": "深雪の如く",
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyNg==",
+          "title": "雪の密室",
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyNw==",
+          "title": "正義の魔法使い",
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyOA==",
+          "title": "幸せの形",
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyOQ==",
+          "title": "失望の雪原",
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMA==",
+          "title": "桜迷宮",
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMQ==",
+          "title": "変えられない夢",
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMg==",
+          "title": "さくらんぼとお兄ちゃん",
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMw==",
+          "title": "壊れゆく春",
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNA==",
+          "title": "夢の終わり",
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNQ==",
+          "title": "枯色の島",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNg==",
+          "title": "記憶の淵",
+          "numberText": "#12"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNw==",
+          "title": "巡りくる季節",
+          "numberText": "#13"
+        }
+      ],
+      "seriesList": [
+        "D.C. ～ダ・カーポ～"
+      ]
+    },
+    {
+      "id": "V29yay0xMDk3NQ==",
+      "title": "絆のアリル セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xNTMzNjI=",
+          "title": "～激戦のプレリュード～",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQwNTE=",
+          "title": "決意のデパーチャー",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQyNzM=",
+          "title": "私だけのザイル",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ1NzU=",
+          "title": "Answer",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ3MDc=",
+          "title": "片思いのライバル",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ5OTY=",
+          "title": "初めての感情",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTUyMjk=",
+          "title": "それぞれのソリチュード",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU0MzM=",
+          "title": "羽ばたきの行方",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU2MTQ=",
+          "title": "友情のシューズ",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU3NDg=",
+          "title": "未知数の私たち",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTYwNDc=",
+          "title": "絶望のタイムリミット",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTYyMzA=",
+          "title": "希望のコネクション",
+          "number": 24,
+          "numberText": "第24話"
+        }
+      ],
+      "seriesList": [
+        "絆のアリル"
+      ]
+    },
+    {
+      "id": "V29yay00MDky",
+      "title": "ヤマノススメ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS04NDE4",
+          "title": "テントに泊まろう！",
+          "number": 1,
+          "numberText": "新一合目"
+        },
+        {
+          "id": "RXBpc29kZS04NzUw",
+          "title": "富士山を見に行こう!!",
+          "number": 2,
+          "numberText": "新二合目"
+        },
+        {
+          "id": "RXBpc29kZS04ODc0",
+          "title": "山に登るということ",
+          "number": 3,
+          "numberText": "新三合目"
+        },
+        {
+          "id": "RXBpc29kZS05Mzk0",
+          "title": "降りた後のお楽しみ！",
+          "number": 4,
+          "numberText": "新四合目"
+        },
+        {
+          "id": "RXBpc29kZS05NjE1",
+          "title": "ゆるして、あげない！",
+          "number": 5,
+          "numberText": "新五合目"
+        },
+        {
+          "id": "RXBpc29kZS05ODY3",
+          "title": "好きな事をするために",
+          "number": 6,
+          "numberText": "新六合目"
+        },
+        {
+          "id": "RXBpc29kZS05OTA3OA==",
+          "title": "ブラノススメ？",
+          "number": 0,
+          "numberText": "六・五合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OA==",
+          "title": "カワノススメ？",
+          "number": 7,
+          "numberText": "新七合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQyNA==",
+          "title": "素敵な思い出を",
+          "number": 8,
+          "numberText": "新八合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDU1OA==",
+          "title": "初めまして、富士山",
+          "number": 9,
+          "numberText": "新九合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDgwNQ==",
+          "title": "富士山って、甘くない…",
+          "number": 10,
+          "numberText": "新十合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDg5Mw==",
+          "title": "もぉ、やだ!!",
+          "number": 11,
+          "numberText": "新十一合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMTExMw==",
+          "title": "Dear My Friend",
+          "number": 12,
+          "numberText": "新十二合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDA5NA==",
+          "title": "不思議なホタルの物語",
+          "number": 13,
+          "numberText": "新十三合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDE5Nw==",
+          "title": "お母さんと霧ヶ峰！",
+          "number": 14,
+          "numberText": "新十四合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDI5NQ==",
+          "title": "雨具の記憶～ねぇ、ゆうか。今なにしてるの？",
+          "number": 15,
+          "numberText": "新十五合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDM3Ng==",
+          "title": "思いをうけついで",
+          "number": 16,
+          "numberText": "新十六合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDQ2OA==",
+          "title": "高いところって、平気？",
+          "number": 17,
+          "numberText": "新十七合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDU2NA==",
+          "title": "アルバイト、始めます！",
+          "number": 18,
+          "numberText": "新十八合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDY2OA==",
+          "title": "宿題が終わらないよぉ",
+          "number": 19,
+          "numberText": "新十九合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDgxMw==",
+          "title": "ここなの飯能大冒険",
+          "number": 20,
+          "numberText": "新二十合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDk2Ng==",
+          "title": "思い出の山へ",
+          "number": 21,
+          "numberText": "新二十一合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTExMQ==",
+          "title": "ともだちになろ？",
+          "number": 22,
+          "numberText": "新二十二合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTIxMA==",
+          "title": "約束",
+          "number": 23,
+          "numberText": "新二十三合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTM0OA==",
+          "title": "さよなら、わたしたちの夏",
+          "number": 24,
+          "numberText": "新二十四合目"
+        },
+        {
+          "id": "RXBpc29kZS05OTA3OQ==",
+          "title": "ヤマノススメ・ベストテン！",
+          "number": 0,
+          "numberText": "いきなり百合目(笑)"
+        }
+      ],
+      "seriesList": [
+        "ヤマノススメ"
+      ]
+    },
+    {
+      "id": "V29yay01NTAw",
+      "title": "One Room セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMDEzNjI=",
+          "title": "花坂結衣のプロローグ",
+          "number": 0,
+          "numberText": "第0話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDE0MTg=",
+          "title": "花坂結衣ははしゃいでる",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDE1MjM=",
+          "title": "花坂結衣は叱られる",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMwMDM=",
+          "title": "花坂結衣は拗ねている",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMxMzI=",
+          "title": "花坂結衣はそばにいる",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMyMzY=",
+          "title": "七橋御乃梨は起こしに来る",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMzNjA=",
+          "title": "七橋御乃梨はしんみりする",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM0NjY=",
+          "title": "七橋御乃梨は無茶を言う",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM3MTI=",
+          "title": "七橋御乃梨はここにいる",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM4MDc=",
+          "title": "天月真白は探してる",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM5NjI=",
+          "title": "天月真白はやってみる",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQwODk=",
+          "title": "天月真白は思い出す",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQyNTY=",
+          "title": "天月真白は待っている",
+          "number": 12,
+          "numberText": "第12話"
+        }
+      ],
+      "seriesList": [
+        "One Room"
+      ]
+    },
+    {
+      "id": "V29yay0xMzY3MA==",
+      "title": "パディントンのぼうけん セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xNjA2Nzk=",
+          "title": "植物には愛を／アートってなあに？",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODA=",
+          "title": "ツリーハウスのお客様／パディントンのスパイ作戦",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODE=",
+          "title": "バースデーパーティーはむずかしい／パディントンのトレーニング",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODI=",
+          "title": "なつかしい味／最強カードをとりもどせ！",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODM=",
+          "title": "卓球はがんばらないでやろう！／思い出のスケート靴",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODQ=",
+          "title": "真夜中の侵入者／バードさんのロッキングチェアー",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODU=",
+          "title": "どっちに投票する？／小さな生き物のおうち",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODY=",
+          "title": "イモムシと新しい先生／夢の宇宙旅行",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODc=",
+          "title": "空想のゲーム／ラッキー！幸運をお願い",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODg=",
+          "title": "ものは捨てずにアップサイクル／農場の動物たちのおでかけ",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODk=",
+          "title": "カリーさんのブラックベリー？／ピザ作りをたのしもう！",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTA=",
+          "title": "お隣さんがやってきた／歯をなくしたジュディ",
+          "number": 12,
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTE=",
+          "title": "おしごとはマーマレードサンドのように／新聞記者、ウィンザーガーデンを走る！",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTI=",
+          "title": "親切は渡していくもの／お花の食べ物をつくろう",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTM=",
+          "title": "たえられない夏のおくりもの／お泊まり会はシンプルに",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTQ=",
+          "title": "生まれてはじめてのかんじゃさん／ミツバチはおともだち",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTU=",
+          "title": "新記録にちょうせん！／けっこんしきをもう一度",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTY=",
+          "title": "古いことはダメじゃない／パディントンと卵",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTc=",
+          "title": "カリーさんと森のたんけん／クマが高所恐怖症？",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTg=",
+          "title": "海賊からのメッセージ／グルーバーさんの決心",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTk=",
+          "title": "思いがけないクリスマス／ウィンザーガーデンパレードを止めるな！",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDA=",
+          "title": "どっちのしつじが いいしつじ？／いきがいだったラジオドラマ",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDE=",
+          "title": "ハロウィーンには幽霊がつきもの／ ペットショーの優勝者はだれ？",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDI=",
+          "title": "パディントン流ゴルフ攻略法／ペットホテルのお客さま",
+          "number": 24,
+          "numberText": "第24話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDM=",
+          "title": "なかよくなれない おとなりさん／みんなでおはなし、キャンプファイア",
+          "number": 25,
+          "numberText": "第25話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDQ=",
+          "title": "おうちを売らないで！／ハリネズミの大ぼうけん",
+          "number": 26,
+          "numberText": "第26話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDU=",
+          "title": "おたんじょうびのロンドンツアー　パート１／おたんじょうびのロンドンツアー　パート２",
+          "number": 27,
+          "numberText": "第27話"
+        }
+      ],
+      "seriesList": [
+        "パディントンのぼうけん"
+      ]
+    },
+    {
+      "id": "V29yay0yMjUy",
+      "title": "＜物語＞シリーズ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yODAz",
+          "title": "猫物語(白) つばさタイガー 其ノ壹",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA0",
+          "title": "猫物語(白) つばさタイガー 其ノ貳",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA1",
+          "title": "猫物語(白) つばさタイガー 其ノ參",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA2",
+          "title": "猫物語(白) つばさタイガー 其ノ肆",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA3",
+          "title": "猫物語(白) つばさタイガー 其ノ伍",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA4",
+          "title": "猫物語(黒) 総集篇I",
+          "numberText": "第禁話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA5",
+          "title": "傾物語 まよいキョンシー 其ノ壹",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEw",
+          "title": "傾物語 まよいキョンシー 其ノ貳",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEx",
+          "title": "傾物語 まよいキョンシー 其ノ參",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEy",
+          "title": "傾物語 まよいキョンシー 其ノ肆",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEz",
+          "title": "化物語 総集篇II",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yODE0",
+          "title": "囮物語 なでこメドゥーサ 其ノ壹",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE1",
+          "title": "囮物語 なでこメドゥーサ 其ノ貳",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE2",
+          "title": "囮物語 なでこメドゥーサ 其ノ參",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE3",
+          "title": "囮物語 なでこメドゥーサ 其ノ肆",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE4",
+          "title": "化物語&偽物語 総集篇III",
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS0yODE5",
+          "title": "鬼物語 しのぶタイム 其ノ壹",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIw",
+          "title": "鬼物語 しのぶタイム 其ノ貳",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIx",
+          "title": "鬼物語 しのぶタイム 其ノ參",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIy",
+          "title": "鬼物語 しのぶタイム 其ノ肆",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIz",
+          "title": "恋物語 ひたぎエンド 其ノ壹",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI0",
+          "title": "恋物語 ひたぎエンド 其ノ貳",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI1",
+          "title": "恋物語 ひたぎエンド 其ノ參",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI2",
+          "title": "恋物語 ひたぎエンド 其ノ肆",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI3",
+          "title": "恋物語 ひたぎエンド 其ノ伍",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI4",
+          "title": "恋物語 ひたぎエンド 其ノ陸",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2NA==",
+          "title": "花物語 するがデビル 其ノ壹",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2NQ==",
+          "title": "花物語 するがデビル 其ノ貳",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2Ng==",
+          "title": "花物語 するがデビル 其ノ參",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2Nw==",
+          "title": "花物語 するがデビル 其ノ肆",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2OA==",
+          "title": "花物語 するがデビル 其ノ伍",
+          "numberText": "第變話"
+        }
+      ],
+      "seriesList": [
+        "〈物語〉"
+      ]
+    },
+    {
+      "id": "V29yay00NDcx",
+      "title": "ハイキュー!! セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0zMjk0OA==",
+          "title": "レッツゴートーキョー!!",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0zOTM1OQ==",
+          "title": "直射日光",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS00NzI0NA==",
+          "title": "“村人B”",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS01ODY3OQ==",
+          "title": "“センターエース”",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS01ODgwMA==",
+          "title": "『欲』",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS01OTY1Nw==",
+          "title": "“テンポ”",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS01OTgwMg==",
+          "title": "月の出",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02MDIyNg==",
+          "title": "幻覚ヒーロー",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02MDQ5Mw==",
+          "title": "VS“傘”",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02MTY1NA==",
+          "title": "歯車",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02MTc5Nw==",
+          "title": "“上”",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02Mjc4OA==",
+          "title": "試合開始!!",
+          "number": 12,
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02MzE1Ng==",
+          "title": "シンプルで純粋な力",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQwMA==",
+          "title": "育ち盛り",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NjM3OA==",
+          "title": "アソビバ",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02ODEzNw==",
+          "title": "次へ",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS02ODc5Mw==",
+          "title": "根性無しの戦い",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS02OTU5OA==",
+          "title": "敗北者達",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS03MTgzNQ==",
+          "title": "鉄壁は何度でも築かれる",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS03MzAzMw==",
+          "title": "払拭",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS03MzE2Mw==",
+          "title": "壊し屋",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS03MzI2OA==",
+          "title": "元・根性無しの戦い",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS03MzQ0Ng==",
+          "title": "“チーム”",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS03MzUzOA==",
+          "title": "極限スイッチ",
+          "number": 24,
+          "numberText": "第24話"
+        },
+        {
+          "id": "RXBpc29kZS03MzkwMg==",
+          "title": "宣戦布告",
+          "number": 25,
+          "numberText": "第25話"
+        }
+      ],
+      "seriesList": [
+        "ハイキュー!!"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/2252-2803__〈物語〉シリーズセカンドシーズン第1話猫物語(白)第懇話『つばさタイガー其ノ壹』.json
+++ b/packages/annict/src/fixture-test/fixtures/2252-2803__〈物語〉シリーズセカンドシーズン第1話猫物語(白)第懇話『つばさタイガー其ノ壹』.json
@@ -1,0 +1,1381 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:24:55.976Z"
+  },
+  "input": {
+    "params": {
+      "title": "〈物語〉シリーズ セカンドシーズン 第1話 猫物語(白) 第懇話『つばさタイガー其ノ壹』"
+    },
+    "annictUrl": "https://annict.com/works/2252/episodes/2803"
+  },
+  "expected": {
+    "id": "V29yay0yMjUy",
+    "title": "＜物語＞シリーズ セカンドシーズン",
+    "episode": {
+      "id": "RXBpc29kZS0yODAz",
+      "title": "猫物語(白) つばさタイガー 其ノ壹",
+      "numberText": "第懇話"
+    }
+  },
+  "variants": [
+    "＜物語＞シリーズ セカンドシーズン",
+    "<物語>シリーズ セカンドシーズン",
+    "セカンドシーズン"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0xMTg1",
+      "title": "D.C.S.S ～ダ・カーポ セカンドシーズン～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yMjkzNg==",
+          "title": "あれから２年…",
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzNw==",
+          "title": "読めない地図",
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzOA==",
+          "title": "ひとつ屋根の下",
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS0yMjkzOQ==",
+          "title": "桜並木の向こうに",
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0MA==",
+          "title": "魔法のしっぽ",
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0MQ==",
+          "title": "美春への手紙",
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Mg==",
+          "title": "すれ違い",
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Mw==",
+          "title": "嵐の予感",
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0NA==",
+          "title": "枯れない想い",
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0NQ==",
+          "title": "入部します！",
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Ng==",
+          "title": "ただいま執筆中！",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0Nw==",
+          "title": "初音島のＷスター",
+          "numberText": "#12"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0OA==",
+          "title": "アイシアの夏",
+          "numberText": "#13"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk0OQ==",
+          "title": "心の扉",
+          "numberText": "#14"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1MA==",
+          "title": "歌声を届けに",
+          "numberText": "#15"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1MQ==",
+          "title": "芽生えた想い",
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Mg==",
+          "title": "音夢と純一",
+          "numberText": "#17"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Mw==",
+          "title": "桜色の蜃気楼",
+          "numberText": "#18"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1NA==",
+          "title": "さくらの言葉",
+          "numberText": "#19"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1NQ==",
+          "title": "戻らない季節",
+          "numberText": "#20"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Ng==",
+          "title": "二人の魔法使い",
+          "numberText": "#21"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1Nw==",
+          "title": "みんなの時間",
+          "numberText": "#22"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1OA==",
+          "title": "沈黙の夏",
+          "numberText": "#23"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk1OQ==",
+          "title": "誓い",
+          "numberText": "#24"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk2MA==",
+          "title": "ダ・カーポ",
+          "numberText": "#25"
+        },
+        {
+          "id": "RXBpc29kZS0yMjk2MQ==",
+          "title": "幸せの鐘",
+          "numberText": "#26"
+        }
+      ],
+      "seriesList": [
+        "D.C. ～ダ・カーポ～"
+      ]
+    },
+    {
+      "id": "V29yay01ODcw",
+      "title": "ハイキュー!! セカンドシーズン OAD「VS\"赤点\"」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ハイキュー!!"
+      ]
+    },
+    {
+      "id": "V29yay00OTE3",
+      "title": "魔法少女なんてもういいですから。セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NzU3OA==",
+          "title": "魔法少女になってメリットはあったの？",
+          "number": 1,
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS03NzcxNw==",
+          "title": "水着って変じゃないですか？",
+          "number": 2,
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS03NzkzMw==",
+          "title": "魔法少女ちや、登場ちやっ！",
+          "number": 3,
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS03OTgzNQ==",
+          "title": "一緒にゆずかを愛でませんか？",
+          "number": 4,
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS04MDI1NQ==",
+          "title": "お姉さんが何でも教えてあげるね",
+          "number": 5,
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS04MDQyNQ==",
+          "title": "だって、このままの格好じゃ…",
+          "number": 6,
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS04MDU0Nw==",
+          "title": "見え過ぎなんじゃないの？",
+          "number": 7,
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS04MDcyMQ==",
+          "title": "僕の話かい？",
+          "number": 8,
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS04MzI5OQ==",
+          "title": "私は働く！家族のために!!",
+          "number": 9,
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS04ODQ0Nw==",
+          "title": "海…ですか？",
+          "number": 10,
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS04ODYxMA==",
+          "title": "選ばれし者よ！いまこそ力を合わせて囚われのプリンセスを救うのじゃ～！",
+          "number": 11,
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS04ODc4MQ==",
+          "title": "魔法少女になってよかった事",
+          "number": 12,
+          "numberText": "#12"
+        }
+      ],
+      "seriesList": [
+        "魔法少女なんてもういいですから。"
+      ]
+    },
+    {
+      "id": "V29yay00ODg0",
+      "title": "12歳。～ちっちゃなムネのトキメキ～ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NzY2Nw==",
+          "title": "スキ・キス・キス!?",
+          "number": 13,
+          "numberText": "#13"
+        },
+        {
+          "id": "RXBpc29kZS03NzY3MA==",
+          "title": "ライバル",
+          "number": 14,
+          "numberText": "#14"
+        },
+        {
+          "id": "RXBpc29kZS03Nzg5MQ==",
+          "title": "ヤクソク",
+          "number": 15,
+          "numberText": "#15"
+        },
+        {
+          "id": "RXBpc29kZS03OTc5Nw==",
+          "title": "ココロ",
+          "number": 16,
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS04MDIyMw==",
+          "title": "アメアガリ",
+          "number": 17,
+          "numberText": "#17"
+        },
+        {
+          "id": "RXBpc29kZS04MDMzMA==",
+          "title": "バランス",
+          "number": 18,
+          "numberText": "#18"
+        },
+        {
+          "id": "RXBpc29kZS04MDUxMw==",
+          "title": "カタオモイ",
+          "number": 19,
+          "numberText": "#19"
+        },
+        {
+          "id": "RXBpc29kZS04MDY4NQ==",
+          "title": "オトナ",
+          "number": 20,
+          "numberText": "#20"
+        },
+        {
+          "id": "RXBpc29kZS04MTQ0OQ==",
+          "title": "シュウガクリョコウ",
+          "number": 21,
+          "numberText": "#21"
+        },
+        {
+          "id": "RXBpc29kZS04Nzk1OA==",
+          "title": "バイバイ",
+          "number": 22,
+          "numberText": "#22"
+        },
+        {
+          "id": "RXBpc29kZS04ODUyNg==",
+          "title": "エイエン",
+          "number": 23,
+          "numberText": "#23"
+        },
+        {
+          "id": "RXBpc29kZS04ODc0NA==",
+          "title": "ダイスキ",
+          "number": 24,
+          "numberText": "#24"
+        }
+      ],
+      "seriesList": [
+        "12歳。"
+      ]
+    },
+    {
+      "id": "V29yay01MTg2",
+      "title": "モンスターストライク セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMDA4ODM=",
+          "title": "前夜祭スペシャル「渇望の果ての理想郷」",
+          "number": 0,
+          "numberText": "第0話"
+        },
+        {
+          "id": "RXBpc29kZS05MDY5Ng==",
+          "title": "転校生は超絶級？",
+          "number": 0,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS05MDY5Nw==",
+          "title": "穢土に轟く忿怒の業拳",
+          "number": 0,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODQ=",
+          "title": "ワルプルギスの夜",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODU=",
+          "title": "焼き鳥・男気・冒険王",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODY=",
+          "title": "炸裂！セブンス・ギャラクシー",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODc=",
+          "title": "温泉、それは聖なる癒し",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODg=",
+          "title": "美人天使の湯けむり事件簿",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4ODk=",
+          "title": "斑目CEO",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTA=",
+          "title": "争いの無い世界",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTE=",
+          "title": "森羅万象の特異点",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTI=",
+          "title": "占い師も困惑！エナジーポイントは何処に？",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTM=",
+          "title": "恐怖の大王",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTQ=",
+          "title": "大予言者ノストラダムス",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTU=",
+          "title": "輪廻へ導く菩提樹の仙峡",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTY=",
+          "title": "それぞれの想い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTc=",
+          "title": "森の英雄 ロビン・フッド",
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTg=",
+          "title": "永久を夢む女神",
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OTk=",
+          "title": "ツクヨミVSツクヨミ零",
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDA=",
+          "title": "女海賊アルビダの奮闘",
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDE=",
+          "title": "神殺しの提督ネイヴィス",
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDI=",
+          "title": "黒髭ティーチの企み",
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDM=",
+          "title": "媽祖の真実",
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5MDQ=",
+          "title": "最後の番人",
+          "numberText": "第23話"
+        }
+      ],
+      "seriesList": [
+        "モンスターストライク"
+      ]
+    },
+    {
+      "id": "V29yay0xMTgy",
+      "title": "D.C.II S.S. ～ダ・カーポII セカンドシーズン～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yNjMyNQ==",
+          "title": "深雪の如く",
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyNg==",
+          "title": "雪の密室",
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyNw==",
+          "title": "正義の魔法使い",
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyOA==",
+          "title": "幸せの形",
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMyOQ==",
+          "title": "失望の雪原",
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMA==",
+          "title": "桜迷宮",
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMQ==",
+          "title": "変えられない夢",
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMg==",
+          "title": "さくらんぼとお兄ちゃん",
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzMw==",
+          "title": "壊れゆく春",
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNA==",
+          "title": "夢の終わり",
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNQ==",
+          "title": "枯色の島",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNg==",
+          "title": "記憶の淵",
+          "numberText": "#12"
+        },
+        {
+          "id": "RXBpc29kZS0yNjMzNw==",
+          "title": "巡りくる季節",
+          "numberText": "#13"
+        }
+      ],
+      "seriesList": [
+        "D.C. ～ダ・カーポ～"
+      ]
+    },
+    {
+      "id": "V29yay0xMDk3NQ==",
+      "title": "絆のアリル セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xNTMzNjI=",
+          "title": "～激戦のプレリュード～",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQwNTE=",
+          "title": "決意のデパーチャー",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQyNzM=",
+          "title": "私だけのザイル",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ1NzU=",
+          "title": "Answer",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ3MDc=",
+          "title": "片思いのライバル",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTQ5OTY=",
+          "title": "初めての感情",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTUyMjk=",
+          "title": "それぞれのソリチュード",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU0MzM=",
+          "title": "羽ばたきの行方",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU2MTQ=",
+          "title": "友情のシューズ",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTU3NDg=",
+          "title": "未知数の私たち",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTYwNDc=",
+          "title": "絶望のタイムリミット",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS0xNTYyMzA=",
+          "title": "希望のコネクション",
+          "number": 24,
+          "numberText": "第24話"
+        }
+      ],
+      "seriesList": [
+        "絆のアリル"
+      ]
+    },
+    {
+      "id": "V29yay00MDky",
+      "title": "ヤマノススメ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS04NDE4",
+          "title": "テントに泊まろう！",
+          "number": 1,
+          "numberText": "新一合目"
+        },
+        {
+          "id": "RXBpc29kZS04NzUw",
+          "title": "富士山を見に行こう!!",
+          "number": 2,
+          "numberText": "新二合目"
+        },
+        {
+          "id": "RXBpc29kZS04ODc0",
+          "title": "山に登るということ",
+          "number": 3,
+          "numberText": "新三合目"
+        },
+        {
+          "id": "RXBpc29kZS05Mzk0",
+          "title": "降りた後のお楽しみ！",
+          "number": 4,
+          "numberText": "新四合目"
+        },
+        {
+          "id": "RXBpc29kZS05NjE1",
+          "title": "ゆるして、あげない！",
+          "number": 5,
+          "numberText": "新五合目"
+        },
+        {
+          "id": "RXBpc29kZS05ODY3",
+          "title": "好きな事をするために",
+          "number": 6,
+          "numberText": "新六合目"
+        },
+        {
+          "id": "RXBpc29kZS05OTA3OA==",
+          "title": "ブラノススメ？",
+          "number": 0,
+          "numberText": "六・五合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA4OA==",
+          "title": "カワノススメ？",
+          "number": 7,
+          "numberText": "新七合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQyNA==",
+          "title": "素敵な思い出を",
+          "number": 8,
+          "numberText": "新八合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDU1OA==",
+          "title": "初めまして、富士山",
+          "number": 9,
+          "numberText": "新九合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDgwNQ==",
+          "title": "富士山って、甘くない…",
+          "number": 10,
+          "numberText": "新十合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMDg5Mw==",
+          "title": "もぉ、やだ!!",
+          "number": 11,
+          "numberText": "新十一合目"
+        },
+        {
+          "id": "RXBpc29kZS0xMTExMw==",
+          "title": "Dear My Friend",
+          "number": 12,
+          "numberText": "新十二合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDA5NA==",
+          "title": "不思議なホタルの物語",
+          "number": 13,
+          "numberText": "新十三合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDE5Nw==",
+          "title": "お母さんと霧ヶ峰！",
+          "number": 14,
+          "numberText": "新十四合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDI5NQ==",
+          "title": "雨具の記憶～ねぇ、ゆうか。今なにしてるの？",
+          "number": 15,
+          "numberText": "新十五合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDM3Ng==",
+          "title": "思いをうけついで",
+          "number": 16,
+          "numberText": "新十六合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDQ2OA==",
+          "title": "高いところって、平気？",
+          "number": 17,
+          "numberText": "新十七合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDU2NA==",
+          "title": "アルバイト、始めます！",
+          "number": 18,
+          "numberText": "新十八合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDY2OA==",
+          "title": "宿題が終わらないよぉ",
+          "number": 19,
+          "numberText": "新十九合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDgxMw==",
+          "title": "ここなの飯能大冒険",
+          "number": 20,
+          "numberText": "新二十合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNDk2Ng==",
+          "title": "思い出の山へ",
+          "number": 21,
+          "numberText": "新二十一合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTExMQ==",
+          "title": "ともだちになろ？",
+          "number": 22,
+          "numberText": "新二十二合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTIxMA==",
+          "title": "約束",
+          "number": 23,
+          "numberText": "新二十三合目"
+        },
+        {
+          "id": "RXBpc29kZS0xNTM0OA==",
+          "title": "さよなら、わたしたちの夏",
+          "number": 24,
+          "numberText": "新二十四合目"
+        },
+        {
+          "id": "RXBpc29kZS05OTA3OQ==",
+          "title": "ヤマノススメ・ベストテン！",
+          "number": 0,
+          "numberText": "いきなり百合目(笑)"
+        }
+      ],
+      "seriesList": [
+        "ヤマノススメ"
+      ]
+    },
+    {
+      "id": "V29yay01NTAw",
+      "title": "One Room セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xMDEzNjI=",
+          "title": "花坂結衣のプロローグ",
+          "number": 0,
+          "numberText": "第0話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDE0MTg=",
+          "title": "花坂結衣ははしゃいでる",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDE1MjM=",
+          "title": "花坂結衣は叱られる",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMwMDM=",
+          "title": "花坂結衣は拗ねている",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMxMzI=",
+          "title": "花坂結衣はそばにいる",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMyMzY=",
+          "title": "七橋御乃梨は起こしに来る",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDMzNjA=",
+          "title": "七橋御乃梨はしんみりする",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM0NjY=",
+          "title": "七橋御乃梨は無茶を言う",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM3MTI=",
+          "title": "七橋御乃梨はここにいる",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM4MDc=",
+          "title": "天月真白は探してる",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM5NjI=",
+          "title": "天月真白はやってみる",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQwODk=",
+          "title": "天月真白は思い出す",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDQyNTY=",
+          "title": "天月真白は待っている",
+          "number": 12,
+          "numberText": "第12話"
+        }
+      ],
+      "seriesList": [
+        "One Room"
+      ]
+    },
+    {
+      "id": "V29yay0xMzY3MA==",
+      "title": "パディントンのぼうけん セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0xNjA2Nzk=",
+          "title": "植物には愛を／アートってなあに？",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODA=",
+          "title": "ツリーハウスのお客様／パディントンのスパイ作戦",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODE=",
+          "title": "バースデーパーティーはむずかしい／パディントンのトレーニング",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODI=",
+          "title": "なつかしい味／最強カードをとりもどせ！",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODM=",
+          "title": "卓球はがんばらないでやろう！／思い出のスケート靴",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODQ=",
+          "title": "真夜中の侵入者／バードさんのロッキングチェアー",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODU=",
+          "title": "どっちに投票する？／小さな生き物のおうち",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODY=",
+          "title": "イモムシと新しい先生／夢の宇宙旅行",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODc=",
+          "title": "空想のゲーム／ラッキー！幸運をお願い",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODg=",
+          "title": "ものは捨てずにアップサイクル／農場の動物たちのおでかけ",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2ODk=",
+          "title": "カリーさんのブラックベリー？／ピザ作りをたのしもう！",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTA=",
+          "title": "お隣さんがやってきた／歯をなくしたジュディ",
+          "number": 12,
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTE=",
+          "title": "おしごとはマーマレードサンドのように／新聞記者、ウィンザーガーデンを走る！",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTI=",
+          "title": "親切は渡していくもの／お花の食べ物をつくろう",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTM=",
+          "title": "たえられない夏のおくりもの／お泊まり会はシンプルに",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTQ=",
+          "title": "生まれてはじめてのかんじゃさん／ミツバチはおともだち",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTU=",
+          "title": "新記録にちょうせん！／けっこんしきをもう一度",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTY=",
+          "title": "古いことはダメじゃない／パディントンと卵",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTc=",
+          "title": "カリーさんと森のたんけん／クマが高所恐怖症？",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTg=",
+          "title": "海賊からのメッセージ／グルーバーさんの決心",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA2OTk=",
+          "title": "思いがけないクリスマス／ウィンザーガーデンパレードを止めるな！",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDA=",
+          "title": "どっちのしつじが いいしつじ？／いきがいだったラジオドラマ",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDE=",
+          "title": "ハロウィーンには幽霊がつきもの／ ペットショーの優勝者はだれ？",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDI=",
+          "title": "パディントン流ゴルフ攻略法／ペットホテルのお客さま",
+          "number": 24,
+          "numberText": "第24話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDM=",
+          "title": "なかよくなれない おとなりさん／みんなでおはなし、キャンプファイア",
+          "number": 25,
+          "numberText": "第25話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDQ=",
+          "title": "おうちを売らないで！／ハリネズミの大ぼうけん",
+          "number": 26,
+          "numberText": "第26話"
+        },
+        {
+          "id": "RXBpc29kZS0xNjA3MDU=",
+          "title": "おたんじょうびのロンドンツアー　パート１／おたんじょうびのロンドンツアー　パート２",
+          "number": 27,
+          "numberText": "第27話"
+        }
+      ],
+      "seriesList": [
+        "パディントンのぼうけん"
+      ]
+    },
+    {
+      "id": "V29yay0yMjUy",
+      "title": "＜物語＞シリーズ セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0yODAz",
+          "title": "猫物語(白) つばさタイガー 其ノ壹",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA0",
+          "title": "猫物語(白) つばさタイガー 其ノ貳",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA1",
+          "title": "猫物語(白) つばさタイガー 其ノ參",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA2",
+          "title": "猫物語(白) つばさタイガー 其ノ肆",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA3",
+          "title": "猫物語(白) つばさタイガー 其ノ伍",
+          "numberText": "第懇話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA4",
+          "title": "猫物語(黒) 総集篇I",
+          "numberText": "第禁話"
+        },
+        {
+          "id": "RXBpc29kZS0yODA5",
+          "title": "傾物語 まよいキョンシー 其ノ壹",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEw",
+          "title": "傾物語 まよいキョンシー 其ノ貳",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEx",
+          "title": "傾物語 まよいキョンシー 其ノ參",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEy",
+          "title": "傾物語 まよいキョンシー 其ノ肆",
+          "numberText": "第閑話"
+        },
+        {
+          "id": "RXBpc29kZS0yODEz",
+          "title": "化物語 総集篇II",
+          "numberText": "#11"
+        },
+        {
+          "id": "RXBpc29kZS0yODE0",
+          "title": "囮物語 なでこメドゥーサ 其ノ壹",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE1",
+          "title": "囮物語 なでこメドゥーサ 其ノ貳",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE2",
+          "title": "囮物語 なでこメドゥーサ 其ノ參",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE3",
+          "title": "囮物語 なでこメドゥーサ 其ノ肆",
+          "numberText": "第亂話"
+        },
+        {
+          "id": "RXBpc29kZS0yODE4",
+          "title": "化物語&偽物語 総集篇III",
+          "numberText": "#16"
+        },
+        {
+          "id": "RXBpc29kZS0yODE5",
+          "title": "鬼物語 しのぶタイム 其ノ壹",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIw",
+          "title": "鬼物語 しのぶタイム 其ノ貳",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIx",
+          "title": "鬼物語 しのぶタイム 其ノ參",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIy",
+          "title": "鬼物語 しのぶタイム 其ノ肆",
+          "numberText": "第忍話"
+        },
+        {
+          "id": "RXBpc29kZS0yODIz",
+          "title": "恋物語 ひたぎエンド 其ノ壹",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI0",
+          "title": "恋物語 ひたぎエンド 其ノ貳",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI1",
+          "title": "恋物語 ひたぎエンド 其ノ參",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI2",
+          "title": "恋物語 ひたぎエンド 其ノ肆",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI3",
+          "title": "恋物語 ひたぎエンド 其ノ伍",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0yODI4",
+          "title": "恋物語 ひたぎエンド 其ノ陸",
+          "numberText": "第恋話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2NA==",
+          "title": "花物語 するがデビル 其ノ壹",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2NQ==",
+          "title": "花物語 するがデビル 其ノ貳",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2Ng==",
+          "title": "花物語 するがデビル 其ノ參",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2Nw==",
+          "title": "花物語 するがデビル 其ノ肆",
+          "numberText": "第變話"
+        },
+        {
+          "id": "RXBpc29kZS0xMDM2OA==",
+          "title": "花物語 するがデビル 其ノ伍",
+          "numberText": "第變話"
+        }
+      ],
+      "seriesList": [
+        "〈物語〉"
+      ]
+    },
+    {
+      "id": "V29yay00NDcx",
+      "title": "ハイキュー!! セカンドシーズン",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0zMjk0OA==",
+          "title": "レッツゴートーキョー!!",
+          "number": 1,
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS0zOTM1OQ==",
+          "title": "直射日光",
+          "number": 2,
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS00NzI0NA==",
+          "title": "“村人B”",
+          "number": 3,
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS01ODY3OQ==",
+          "title": "“センターエース”",
+          "number": 4,
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS01ODgwMA==",
+          "title": "『欲』",
+          "number": 5,
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS01OTY1Nw==",
+          "title": "“テンポ”",
+          "number": 6,
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS01OTgwMg==",
+          "title": "月の出",
+          "number": 7,
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02MDIyNg==",
+          "title": "幻覚ヒーロー",
+          "number": 8,
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02MDQ5Mw==",
+          "title": "VS“傘”",
+          "number": 9,
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02MTY1NA==",
+          "title": "歯車",
+          "number": 10,
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02MTc5Nw==",
+          "title": "“上”",
+          "number": 11,
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02Mjc4OA==",
+          "title": "試合開始!!",
+          "number": 12,
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02MzE1Ng==",
+          "title": "シンプルで純粋な力",
+          "number": 13,
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQwMA==",
+          "title": "育ち盛り",
+          "number": 14,
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NjM3OA==",
+          "title": "アソビバ",
+          "number": 15,
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02ODEzNw==",
+          "title": "次へ",
+          "number": 16,
+          "numberText": "第16話"
+        },
+        {
+          "id": "RXBpc29kZS02ODc5Mw==",
+          "title": "根性無しの戦い",
+          "number": 17,
+          "numberText": "第17話"
+        },
+        {
+          "id": "RXBpc29kZS02OTU5OA==",
+          "title": "敗北者達",
+          "number": 18,
+          "numberText": "第18話"
+        },
+        {
+          "id": "RXBpc29kZS03MTgzNQ==",
+          "title": "鉄壁は何度でも築かれる",
+          "number": 19,
+          "numberText": "第19話"
+        },
+        {
+          "id": "RXBpc29kZS03MzAzMw==",
+          "title": "払拭",
+          "number": 20,
+          "numberText": "第20話"
+        },
+        {
+          "id": "RXBpc29kZS03MzE2Mw==",
+          "title": "壊し屋",
+          "number": 21,
+          "numberText": "第21話"
+        },
+        {
+          "id": "RXBpc29kZS03MzI2OA==",
+          "title": "元・根性無しの戦い",
+          "number": 22,
+          "numberText": "第22話"
+        },
+        {
+          "id": "RXBpc29kZS03MzQ0Ng==",
+          "title": "“チーム”",
+          "number": 23,
+          "numberText": "第23話"
+        },
+        {
+          "id": "RXBpc29kZS03MzUzOA==",
+          "title": "極限スイッチ",
+          "number": 24,
+          "numberText": "第24話"
+        },
+        {
+          "id": "RXBpc29kZS03MzkwMg==",
+          "title": "宣戦布告",
+          "number": 25,
+          "numberText": "第25話"
+        }
+      ],
+      "seriesList": [
+        "ハイキュー!!"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/3279__劇場版CLANNAD.json
+++ b/packages/annict/src/fixture-test/fixtures/3279__劇場版CLANNAD.json
@@ -1,0 +1,344 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:24:01.727Z"
+  },
+  "input": {
+    "params": {
+      "title": "劇場版CLANNAD"
+    },
+    "annictUrl": "https://annict.com/works/3279"
+  },
+  "expected": {
+    "id": "V29yay0zMjc5",
+    "title": "劇場版 CLANNAD -クラナド-",
+    "episode": null
+  },
+  "variants": [
+    "劇場版 CLANNAD -クラナド-",
+    " CLANNAD -クラナド-",
+    "CLANNAD",
+    "クラナド"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMjc5",
+      "title": "劇場版 CLANNAD -クラナド-",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "CLANNAD"
+      ]
+    },
+    {
+      "id": "V29yay02MTQ=",
+      "title": "CLANNAD -クラナド-",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0zNDE2",
+          "title": "桜舞い散る坂道で",
+          "number": 1,
+          "numberText": "第1回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDE3",
+          "title": "最初の一歩",
+          "number": 2,
+          "numberText": "第2回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDE4",
+          "title": "涙のあとにもう一度",
+          "number": 3,
+          "numberText": "第3回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDE5",
+          "title": "仲間をさがそう",
+          "number": 4,
+          "numberText": "第4回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIw",
+          "title": "彫刻のある風景",
+          "number": 5,
+          "numberText": "第5回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIx",
+          "title": "姉と妹の創立者祭",
+          "number": 6,
+          "numberText": "第6回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIy",
+          "title": "星形の気持ち",
+          "number": 7,
+          "numberText": "第7回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIz",
+          "title": "黄昏に消える風",
+          "number": 8,
+          "numberText": "第8回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI0",
+          "title": "夢の最後まで",
+          "number": 9,
+          "numberText": "第9回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI1",
+          "title": "天才少女の挑戦",
+          "number": 10,
+          "numberText": "第10回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI2",
+          "title": "放課後の狂想曲",
+          "number": 11,
+          "numberText": "第11回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI3",
+          "title": "かくされた世界",
+          "number": 12,
+          "numberText": "第12回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI4",
+          "title": "思い出の庭を",
+          "number": 13,
+          "numberText": "第13回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI5",
+          "title": "Theory of Everything",
+          "number": 14,
+          "numberText": "第14回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMw",
+          "title": "困った問題",
+          "number": 15,
+          "numberText": "第15回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMx",
+          "title": "3 on 3",
+          "number": 16,
+          "numberText": "第16回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMy",
+          "title": "不在の空間",
+          "number": 17,
+          "numberText": "第17回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMz",
+          "title": "逆転の秘策",
+          "number": 18,
+          "numberText": "第18回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM0",
+          "title": "新しい生活",
+          "number": 19,
+          "numberText": "第19回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM1",
+          "title": "秘められた過去",
+          "number": 20,
+          "numberText": "第20回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM2",
+          "title": "学園祭にむけて",
+          "number": 21,
+          "numberText": "第21回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM3",
+          "title": "影二つ",
+          "number": 22,
+          "numberText": "最終回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM4",
+          "title": "夏休みの出来事",
+          "number": 23,
+          "numberText": "番外編"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM5",
+          "title": "もうひとつの世界 智代編",
+          "number": 24,
+          "numberText": "番外編"
+        }
+      ],
+      "seriesList": [
+        "CLANNAD"
+      ]
+    },
+    {
+      "id": "V29yay02MTU=",
+      "title": "CLANNAD～AFTER STORY～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0zNDQw",
+          "title": "夏の終わりのサヨナラ",
+          "number": 1,
+          "numberText": "第1回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQx",
+          "title": "いつわりの愛をさがして",
+          "number": 2,
+          "numberText": "第2回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQy",
+          "title": "すれちがう心",
+          "number": 3,
+          "numberText": "第3回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQz",
+          "title": "あの日と同じ笑顔で",
+          "number": 4,
+          "numberText": "第4回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ0",
+          "title": "君のいた季節",
+          "number": 5,
+          "numberText": "第5回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ1",
+          "title": "ずっとあなたのそばに",
+          "number": 6,
+          "numberText": "第6回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ2",
+          "title": "彼女の居場所",
+          "number": 7,
+          "numberText": "第7回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ3",
+          "title": "勇気ある闘い",
+          "number": 8,
+          "numberText": "第8回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ4",
+          "title": "坂道の途中",
+          "number": 9,
+          "numberText": "第9回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ5",
+          "title": "始まりの季節",
+          "number": 10,
+          "numberText": "第10回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUw",
+          "title": "約束の創立者祭",
+          "number": 11,
+          "numberText": "第11回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUx",
+          "title": "突然の出来事",
+          "number": 12,
+          "numberText": "第12回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUy",
+          "title": "卒業",
+          "number": 13,
+          "numberText": "第13回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUz",
+          "title": "新しい家族",
+          "number": 14,
+          "numberText": "第14回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU0",
+          "title": "夏の名残りに",
+          "number": 15,
+          "numberText": "第15回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU1",
+          "title": "白い闇",
+          "number": 16,
+          "numberText": "第16回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU2",
+          "title": "夏時間",
+          "number": 17,
+          "numberText": "第17回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU3",
+          "title": "大地の果て",
+          "number": 18,
+          "numberText": "第18回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU4",
+          "title": "家路",
+          "number": 19,
+          "numberText": "第19回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU5",
+          "title": "汐風の戯れ",
+          "number": 20,
+          "numberText": "第20回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYw",
+          "title": "世界の終わり",
+          "number": 21,
+          "numberText": "第21回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYx",
+          "title": "小さな手のひら",
+          "number": 22,
+          "numberText": "最終回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYy",
+          "title": "一年前の出来事",
+          "numberText": "番外編"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYz",
+          "title": "もうひとつの世界 杏編",
+          "numberText": "番外編"
+        },
+        {
+          "id": "RXBpc29kZS0zNDY0",
+          "title": "緑の樹の下で",
+          "numberText": "総集編"
+        }
+      ],
+      "seriesList": [
+        "CLANNAD"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/3279__劇場版CLANNAD_.json
+++ b/packages/annict/src/fixture-test/fixtures/3279__劇場版CLANNAD_.json
@@ -1,0 +1,345 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:24:09.853Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "劇場版CLANNAD",
+      "episodeTitle": ""
+    },
+    "annictUrl": "https://annict.com/works/3279"
+  },
+  "expected": {
+    "id": "V29yay0zMjc5",
+    "title": "劇場版 CLANNAD -クラナド-",
+    "episode": null
+  },
+  "variants": [
+    "劇場版 CLANNAD -クラナド-",
+    " CLANNAD -クラナド-",
+    "CLANNAD",
+    "クラナド"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMjc5",
+      "title": "劇場版 CLANNAD -クラナド-",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "CLANNAD"
+      ]
+    },
+    {
+      "id": "V29yay02MTQ=",
+      "title": "CLANNAD -クラナド-",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0zNDE2",
+          "title": "桜舞い散る坂道で",
+          "number": 1,
+          "numberText": "第1回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDE3",
+          "title": "最初の一歩",
+          "number": 2,
+          "numberText": "第2回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDE4",
+          "title": "涙のあとにもう一度",
+          "number": 3,
+          "numberText": "第3回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDE5",
+          "title": "仲間をさがそう",
+          "number": 4,
+          "numberText": "第4回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIw",
+          "title": "彫刻のある風景",
+          "number": 5,
+          "numberText": "第5回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIx",
+          "title": "姉と妹の創立者祭",
+          "number": 6,
+          "numberText": "第6回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIy",
+          "title": "星形の気持ち",
+          "number": 7,
+          "numberText": "第7回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDIz",
+          "title": "黄昏に消える風",
+          "number": 8,
+          "numberText": "第8回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI0",
+          "title": "夢の最後まで",
+          "number": 9,
+          "numberText": "第9回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI1",
+          "title": "天才少女の挑戦",
+          "number": 10,
+          "numberText": "第10回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI2",
+          "title": "放課後の狂想曲",
+          "number": 11,
+          "numberText": "第11回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI3",
+          "title": "かくされた世界",
+          "number": 12,
+          "numberText": "第12回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI4",
+          "title": "思い出の庭を",
+          "number": 13,
+          "numberText": "第13回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDI5",
+          "title": "Theory of Everything",
+          "number": 14,
+          "numberText": "第14回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMw",
+          "title": "困った問題",
+          "number": 15,
+          "numberText": "第15回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMx",
+          "title": "3 on 3",
+          "number": 16,
+          "numberText": "第16回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMy",
+          "title": "不在の空間",
+          "number": 17,
+          "numberText": "第17回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDMz",
+          "title": "逆転の秘策",
+          "number": 18,
+          "numberText": "第18回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM0",
+          "title": "新しい生活",
+          "number": 19,
+          "numberText": "第19回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM1",
+          "title": "秘められた過去",
+          "number": 20,
+          "numberText": "第20回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM2",
+          "title": "学園祭にむけて",
+          "number": 21,
+          "numberText": "第21回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM3",
+          "title": "影二つ",
+          "number": 22,
+          "numberText": "最終回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM4",
+          "title": "夏休みの出来事",
+          "number": 23,
+          "numberText": "番外編"
+        },
+        {
+          "id": "RXBpc29kZS0zNDM5",
+          "title": "もうひとつの世界 智代編",
+          "number": 24,
+          "numberText": "番外編"
+        }
+      ],
+      "seriesList": [
+        "CLANNAD"
+      ]
+    },
+    {
+      "id": "V29yay02MTU=",
+      "title": "CLANNAD～AFTER STORY～",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS0zNDQw",
+          "title": "夏の終わりのサヨナラ",
+          "number": 1,
+          "numberText": "第1回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQx",
+          "title": "いつわりの愛をさがして",
+          "number": 2,
+          "numberText": "第2回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQy",
+          "title": "すれちがう心",
+          "number": 3,
+          "numberText": "第3回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQz",
+          "title": "あの日と同じ笑顔で",
+          "number": 4,
+          "numberText": "第4回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ0",
+          "title": "君のいた季節",
+          "number": 5,
+          "numberText": "第5回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ1",
+          "title": "ずっとあなたのそばに",
+          "number": 6,
+          "numberText": "第6回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ2",
+          "title": "彼女の居場所",
+          "number": 7,
+          "numberText": "第7回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ3",
+          "title": "勇気ある闘い",
+          "number": 8,
+          "numberText": "第8回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ4",
+          "title": "坂道の途中",
+          "number": 9,
+          "numberText": "第9回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDQ5",
+          "title": "始まりの季節",
+          "number": 10,
+          "numberText": "第10回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUw",
+          "title": "約束の創立者祭",
+          "number": 11,
+          "numberText": "第11回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUx",
+          "title": "突然の出来事",
+          "number": 12,
+          "numberText": "第12回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUy",
+          "title": "卒業",
+          "number": 13,
+          "numberText": "第13回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDUz",
+          "title": "新しい家族",
+          "number": 14,
+          "numberText": "第14回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU0",
+          "title": "夏の名残りに",
+          "number": 15,
+          "numberText": "第15回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU1",
+          "title": "白い闇",
+          "number": 16,
+          "numberText": "第16回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU2",
+          "title": "夏時間",
+          "number": 17,
+          "numberText": "第17回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU3",
+          "title": "大地の果て",
+          "number": 18,
+          "numberText": "第18回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU4",
+          "title": "家路",
+          "number": 19,
+          "numberText": "第19回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDU5",
+          "title": "汐風の戯れ",
+          "number": 20,
+          "numberText": "第20回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYw",
+          "title": "世界の終わり",
+          "number": 21,
+          "numberText": "第21回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYx",
+          "title": "小さな手のひら",
+          "number": 22,
+          "numberText": "最終回"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYy",
+          "title": "一年前の出来事",
+          "numberText": "番外編"
+        },
+        {
+          "id": "RXBpc29kZS0zNDYz",
+          "title": "もうひとつの世界 杏編",
+          "numberText": "番外編"
+        },
+        {
+          "id": "RXBpc29kZS0zNDY0",
+          "title": "緑の樹の下で",
+          "numberText": "総集編"
+        }
+      ],
+      "seriesList": [
+        "CLANNAD"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/338-6560__俺の妹がこんなに可愛いわけがないTRUEROUTE_第12話_俺の妹の人生相談がこれで終わるわけがない.json
+++ b/packages/annict/src/fixture-test/fixtures/338-6560__俺の妹がこんなに可愛いわけがないTRUEROUTE_第12話_俺の妹の人生相談がこれで終わるわけがない.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:27:52.452Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "俺の妹がこんなに可愛いわけがないTRUEROUTE",
+      "episodeNumber": "第12話",
+      "episodeTitle": "俺の妹の人生相談がこれで終わるわけがない"
+    },
+    "annictUrl": "https://annict.com/works/338/episodes/6560"
+  },
+  "expected": {
+    "id": "V29yay0zMzg=",
+    "title": "俺の妹がこんなに可愛いわけがない",
+    "episode": {
+      "id": "RXBpc29kZS02NTYw",
+      "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+      "numberText": "第12話 (TRUE ROUTE)"
+    }
+  },
+  "variants": [
+    "俺の妹がこんなに可愛いわけがない"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMzg=",
+      "title": "俺の妹がこんなに可愛いわけがない",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTQ4",
+          "title": "俺が妹と恋をするわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ5",
+          "title": "俺が妹とオフ会に行くわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUw",
+          "title": "俺の妹がこんなに可愛いわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUx",
+          "title": "俺の妹が夏コミとか行くわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUy",
+          "title": "俺の妹の親友がこんなに××なわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUz",
+          "title": "俺の幼馴染がこんなに可愛いわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU0",
+          "title": "俺の妹がこんなに小説家なわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU1",
+          "title": "俺の妹がこんなにアニメ化なわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU2",
+          "title": "俺の妹がこんなにエロゲー三昧なわけがない",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU3",
+          "title": "俺の妹がこんなにコスプレなわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU4",
+          "title": "俺の妹がこんなにメイドなわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU5",
+          "title": "俺の妹の人生相談がこれで終わるわけがない GOOD END",
+          "numberText": "第12話 (GOOD END)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYw",
+          "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+          "numberText": "第12話 (TRUE ROUTE)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYx",
+          "title": "俺の後輩がこんなに腐ってるわけがない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYy",
+          "title": "俺の後輩がこんなに可愛いわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYz",
+          "title": "俺の妹がこれで最終回なわけがない",
+          "numberText": "第15話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    },
+    {
+      "id": "V29yay0zMzk=",
+      "title": "俺の妹がこんなに可愛いわけがない。",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTMy",
+          "title": "俺の妹が再び帰ってくるわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTMz",
+          "title": "信じて送り出したお兄さんが携帯美少女ゲームにドハマリして セクハラしてくるようになるわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM0",
+          "title": "俺の友達が眼鏡を外すわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM1",
+          "title": "俺の妹のライバルが来日するわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM2",
+          "title": "俺が妹の彼氏なわけがないし、俺の妹に彼氏がいるわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM3",
+          "title": "俺の妹が家に彼氏をつれてくるわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM4",
+          "title": "俺が後輩と恋人同士になるわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM5",
+          "title": "俺が後輩とひと夏の思い出を作るわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQw",
+          "title": "俺の妹がこんなに可愛いわけがない!",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQx",
+          "title": "俺の妹がウエディングドレスを着るわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQy",
+          "title": "一人暮らしの兄貴の部屋に妹たちが押しかけるわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQz",
+          "title": "マジ天使すぎるあやせたんが一人暮らしの俺んちに降臨するわけがない",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ0",
+          "title": "妹（あたし）が兄（アイツ）に恋なんてするわけない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ1",
+          "title": "俺が彼女に告白なんてするわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ2",
+          "title": "俺の妹がこんなに可愛い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ3",
+          "title": "俺の妹がこんなに可愛いわけがない。",
+          "numberText": "第16話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/338-6560__俺の妹がこんなに可愛いわけがないTRUEROUTE_第12話俺の妹の人生相談がこれで終わるわけがない.json
+++ b/packages/annict/src/fixture-test/fixtures/338-6560__俺の妹がこんなに可愛いわけがないTRUEROUTE_第12話俺の妹の人生相談がこれで終わるわけがない.json
@@ -1,0 +1,206 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:27:38.804Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "俺の妹がこんなに可愛いわけがないTRUEROUTE",
+      "episodeTitle": "第12話 俺の妹の人生相談がこれで終わるわけがない"
+    },
+    "annictUrl": "https://annict.com/works/338/episodes/6560"
+  },
+  "expected": {
+    "id": "V29yay0zMzg=",
+    "title": "俺の妹がこんなに可愛いわけがない",
+    "episode": {
+      "id": "RXBpc29kZS02NTYw",
+      "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+      "numberText": "第12話 (TRUE ROUTE)"
+    }
+  },
+  "variants": [
+    "俺の妹がこんなに可愛いわけがない"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMzg=",
+      "title": "俺の妹がこんなに可愛いわけがない",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTQ4",
+          "title": "俺が妹と恋をするわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ5",
+          "title": "俺が妹とオフ会に行くわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUw",
+          "title": "俺の妹がこんなに可愛いわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUx",
+          "title": "俺の妹が夏コミとか行くわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUy",
+          "title": "俺の妹の親友がこんなに××なわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUz",
+          "title": "俺の幼馴染がこんなに可愛いわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU0",
+          "title": "俺の妹がこんなに小説家なわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU1",
+          "title": "俺の妹がこんなにアニメ化なわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU2",
+          "title": "俺の妹がこんなにエロゲー三昧なわけがない",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU3",
+          "title": "俺の妹がこんなにコスプレなわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU4",
+          "title": "俺の妹がこんなにメイドなわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU5",
+          "title": "俺の妹の人生相談がこれで終わるわけがない GOOD END",
+          "numberText": "第12話 (GOOD END)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYw",
+          "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+          "numberText": "第12話 (TRUE ROUTE)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYx",
+          "title": "俺の後輩がこんなに腐ってるわけがない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYy",
+          "title": "俺の後輩がこんなに可愛いわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYz",
+          "title": "俺の妹がこれで最終回なわけがない",
+          "numberText": "第15話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    },
+    {
+      "id": "V29yay0zMzk=",
+      "title": "俺の妹がこんなに可愛いわけがない。",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTMy",
+          "title": "俺の妹が再び帰ってくるわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTMz",
+          "title": "信じて送り出したお兄さんが携帯美少女ゲームにドハマリして セクハラしてくるようになるわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM0",
+          "title": "俺の友達が眼鏡を外すわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM1",
+          "title": "俺の妹のライバルが来日するわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM2",
+          "title": "俺が妹の彼氏なわけがないし、俺の妹に彼氏がいるわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM3",
+          "title": "俺の妹が家に彼氏をつれてくるわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM4",
+          "title": "俺が後輩と恋人同士になるわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM5",
+          "title": "俺が後輩とひと夏の思い出を作るわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQw",
+          "title": "俺の妹がこんなに可愛いわけがない!",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQx",
+          "title": "俺の妹がウエディングドレスを着るわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQy",
+          "title": "一人暮らしの兄貴の部屋に妹たちが押しかけるわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQz",
+          "title": "マジ天使すぎるあやせたんが一人暮らしの俺んちに降臨するわけがない",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ0",
+          "title": "妹（あたし）が兄（アイツ）に恋なんてするわけない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ1",
+          "title": "俺が彼女に告白なんてするわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ2",
+          "title": "俺の妹がこんなに可愛い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ3",
+          "title": "俺の妹がこんなに可愛いわけがない。",
+          "numberText": "第16話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/338-6560__俺の妹がこんなに可愛いわけがないTRUEROUTE第12話俺の妹の人生相談がこれで終わるわけがない.json
+++ b/packages/annict/src/fixture-test/fixtures/338-6560__俺の妹がこんなに可愛いわけがないTRUEROUTE第12話俺の妹の人生相談がこれで終わるわけがない.json
@@ -1,0 +1,205 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:27:30.230Z"
+  },
+  "input": {
+    "params": {
+      "title": "俺の妹がこんなに可愛いわけがないTRUEROUTE 第12話 俺の妹の人生相談がこれで終わるわけがない"
+    },
+    "annictUrl": "https://annict.com/works/338/episodes/6560"
+  },
+  "expected": {
+    "id": "V29yay0zMzg=",
+    "title": "俺の妹がこんなに可愛いわけがない",
+    "episode": {
+      "id": "RXBpc29kZS02NTYw",
+      "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+      "numberText": "第12話 (TRUE ROUTE)"
+    }
+  },
+  "variants": [
+    "俺の妹がこんなに可愛いわけがない"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMzg=",
+      "title": "俺の妹がこんなに可愛いわけがない",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTQ4",
+          "title": "俺が妹と恋をするわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ5",
+          "title": "俺が妹とオフ会に行くわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUw",
+          "title": "俺の妹がこんなに可愛いわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUx",
+          "title": "俺の妹が夏コミとか行くわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUy",
+          "title": "俺の妹の親友がこんなに××なわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUz",
+          "title": "俺の幼馴染がこんなに可愛いわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU0",
+          "title": "俺の妹がこんなに小説家なわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU1",
+          "title": "俺の妹がこんなにアニメ化なわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU2",
+          "title": "俺の妹がこんなにエロゲー三昧なわけがない",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU3",
+          "title": "俺の妹がこんなにコスプレなわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU4",
+          "title": "俺の妹がこんなにメイドなわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU5",
+          "title": "俺の妹の人生相談がこれで終わるわけがない GOOD END",
+          "numberText": "第12話 (GOOD END)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYw",
+          "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+          "numberText": "第12話 (TRUE ROUTE)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYx",
+          "title": "俺の後輩がこんなに腐ってるわけがない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYy",
+          "title": "俺の後輩がこんなに可愛いわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYz",
+          "title": "俺の妹がこれで最終回なわけがない",
+          "numberText": "第15話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    },
+    {
+      "id": "V29yay0zMzk=",
+      "title": "俺の妹がこんなに可愛いわけがない。",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTMy",
+          "title": "俺の妹が再び帰ってくるわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTMz",
+          "title": "信じて送り出したお兄さんが携帯美少女ゲームにドハマリして セクハラしてくるようになるわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM0",
+          "title": "俺の友達が眼鏡を外すわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM1",
+          "title": "俺の妹のライバルが来日するわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM2",
+          "title": "俺が妹の彼氏なわけがないし、俺の妹に彼氏がいるわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM3",
+          "title": "俺の妹が家に彼氏をつれてくるわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM4",
+          "title": "俺が後輩と恋人同士になるわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM5",
+          "title": "俺が後輩とひと夏の思い出を作るわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQw",
+          "title": "俺の妹がこんなに可愛いわけがない!",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQx",
+          "title": "俺の妹がウエディングドレスを着るわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQy",
+          "title": "一人暮らしの兄貴の部屋に妹たちが押しかけるわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQz",
+          "title": "マジ天使すぎるあやせたんが一人暮らしの俺んちに降臨するわけがない",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ0",
+          "title": "妹（あたし）が兄（アイツ）に恋なんてするわけない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ1",
+          "title": "俺が彼女に告白なんてするわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ2",
+          "title": "俺の妹がこんなに可愛い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ3",
+          "title": "俺の妹がこんなに可愛いわけがない。",
+          "numberText": "第16話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/339-6545__俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話_第14話.json
+++ b/packages/annict/src/fixture-test/fixtures/339-6545__俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話_第14話.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:26:49.359Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話",
+      "episodeTitle": "第14話"
+    },
+    "annictUrl": "https://annict.com/works/339/episodes/6545"
+  },
+  "expected": {
+    "id": "V29yay0zMzk=",
+    "title": "俺の妹がこんなに可愛いわけがない。",
+    "episode": {
+      "id": "RXBpc29kZS02NTQ1",
+      "title": "俺が彼女に告白なんてするわけがない",
+      "numberText": "第14話"
+    }
+  },
+  "variants": [
+    "俺の妹がこんなに可愛いわけがない。",
+    "俺の妹がこんなに可愛いわけがない"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMzg=",
+      "title": "俺の妹がこんなに可愛いわけがない",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTQ4",
+          "title": "俺が妹と恋をするわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ5",
+          "title": "俺が妹とオフ会に行くわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUw",
+          "title": "俺の妹がこんなに可愛いわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUx",
+          "title": "俺の妹が夏コミとか行くわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUy",
+          "title": "俺の妹の親友がこんなに××なわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUz",
+          "title": "俺の幼馴染がこんなに可愛いわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU0",
+          "title": "俺の妹がこんなに小説家なわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU1",
+          "title": "俺の妹がこんなにアニメ化なわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU2",
+          "title": "俺の妹がこんなにエロゲー三昧なわけがない",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU3",
+          "title": "俺の妹がこんなにコスプレなわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU4",
+          "title": "俺の妹がこんなにメイドなわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU5",
+          "title": "俺の妹の人生相談がこれで終わるわけがない GOOD END",
+          "numberText": "第12話 (GOOD END)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYw",
+          "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+          "numberText": "第12話 (TRUE ROUTE)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYx",
+          "title": "俺の後輩がこんなに腐ってるわけがない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYy",
+          "title": "俺の後輩がこんなに可愛いわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYz",
+          "title": "俺の妹がこれで最終回なわけがない",
+          "numberText": "第15話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    },
+    {
+      "id": "V29yay0zMzk=",
+      "title": "俺の妹がこんなに可愛いわけがない。",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTMy",
+          "title": "俺の妹が再び帰ってくるわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTMz",
+          "title": "信じて送り出したお兄さんが携帯美少女ゲームにドハマリして セクハラしてくるようになるわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM0",
+          "title": "俺の友達が眼鏡を外すわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM1",
+          "title": "俺の妹のライバルが来日するわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM2",
+          "title": "俺が妹の彼氏なわけがないし、俺の妹に彼氏がいるわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM3",
+          "title": "俺の妹が家に彼氏をつれてくるわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM4",
+          "title": "俺が後輩と恋人同士になるわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM5",
+          "title": "俺が後輩とひと夏の思い出を作るわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQw",
+          "title": "俺の妹がこんなに可愛いわけがない!",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQx",
+          "title": "俺の妹がウエディングドレスを着るわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQy",
+          "title": "一人暮らしの兄貴の部屋に妹たちが押しかけるわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQz",
+          "title": "マジ天使すぎるあやせたんが一人暮らしの俺んちに降臨するわけがない",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ0",
+          "title": "妹（あたし）が兄（アイツ）に恋なんてするわけない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ1",
+          "title": "俺が彼女に告白なんてするわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ2",
+          "title": "俺の妹がこんなに可愛い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ3",
+          "title": "俺の妹がこんなに可愛いわけがない。",
+          "numberText": "第16話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/339-6545__俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話_第14話_.json
+++ b/packages/annict/src/fixture-test/fixtures/339-6545__俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話_第14話_.json
@@ -1,0 +1,208 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:26:57.881Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話",
+      "episodeNumber": "第14話",
+      "episodeTitle": ""
+    },
+    "annictUrl": "https://annict.com/works/339/episodes/6545"
+  },
+  "expected": {
+    "id": "V29yay0zMzk=",
+    "title": "俺の妹がこんなに可愛いわけがない。",
+    "episode": {
+      "id": "RXBpc29kZS02NTQ1",
+      "title": "俺が彼女に告白なんてするわけがない",
+      "numberText": "第14話"
+    }
+  },
+  "variants": [
+    "俺の妹がこんなに可愛いわけがない。",
+    "俺の妹がこんなに可愛いわけがない"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMzg=",
+      "title": "俺の妹がこんなに可愛いわけがない",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTQ4",
+          "title": "俺が妹と恋をするわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ5",
+          "title": "俺が妹とオフ会に行くわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUw",
+          "title": "俺の妹がこんなに可愛いわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUx",
+          "title": "俺の妹が夏コミとか行くわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUy",
+          "title": "俺の妹の親友がこんなに××なわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUz",
+          "title": "俺の幼馴染がこんなに可愛いわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU0",
+          "title": "俺の妹がこんなに小説家なわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU1",
+          "title": "俺の妹がこんなにアニメ化なわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU2",
+          "title": "俺の妹がこんなにエロゲー三昧なわけがない",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU3",
+          "title": "俺の妹がこんなにコスプレなわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU4",
+          "title": "俺の妹がこんなにメイドなわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU5",
+          "title": "俺の妹の人生相談がこれで終わるわけがない GOOD END",
+          "numberText": "第12話 (GOOD END)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYw",
+          "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+          "numberText": "第12話 (TRUE ROUTE)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYx",
+          "title": "俺の後輩がこんなに腐ってるわけがない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYy",
+          "title": "俺の後輩がこんなに可愛いわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYz",
+          "title": "俺の妹がこれで最終回なわけがない",
+          "numberText": "第15話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    },
+    {
+      "id": "V29yay0zMzk=",
+      "title": "俺の妹がこんなに可愛いわけがない。",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTMy",
+          "title": "俺の妹が再び帰ってくるわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTMz",
+          "title": "信じて送り出したお兄さんが携帯美少女ゲームにドハマリして セクハラしてくるようになるわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM0",
+          "title": "俺の友達が眼鏡を外すわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM1",
+          "title": "俺の妹のライバルが来日するわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM2",
+          "title": "俺が妹の彼氏なわけがないし、俺の妹に彼氏がいるわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM3",
+          "title": "俺の妹が家に彼氏をつれてくるわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM4",
+          "title": "俺が後輩と恋人同士になるわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM5",
+          "title": "俺が後輩とひと夏の思い出を作るわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQw",
+          "title": "俺の妹がこんなに可愛いわけがない!",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQx",
+          "title": "俺の妹がウエディングドレスを着るわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQy",
+          "title": "一人暮らしの兄貴の部屋に妹たちが押しかけるわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQz",
+          "title": "マジ天使すぎるあやせたんが一人暮らしの俺んちに降臨するわけがない",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ0",
+          "title": "妹（あたし）が兄（アイツ）に恋なんてするわけない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ1",
+          "title": "俺が彼女に告白なんてするわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ2",
+          "title": "俺の妹がこんなに可愛い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ3",
+          "title": "俺の妹がこんなに可愛いわけがない。",
+          "numberText": "第16話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/339-6545__俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話第14話.json
+++ b/packages/annict/src/fixture-test/fixtures/339-6545__俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話第14話.json
@@ -1,0 +1,206 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T10:26:40.120Z"
+  },
+  "input": {
+    "params": {
+      "title": "俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話 第14話"
+    },
+    "annictUrl": "https://annict.com/works/339/episodes/6545"
+  },
+  "expected": {
+    "id": "V29yay0zMzk=",
+    "title": "俺の妹がこんなに可愛いわけがない。",
+    "episode": {
+      "id": "RXBpc29kZS02NTQ1",
+      "title": "俺が彼女に告白なんてするわけがない",
+      "numberText": "第14話"
+    }
+  },
+  "variants": [
+    "俺の妹がこんなに可愛いわけがない。",
+    "俺の妹がこんなに可愛いわけがない"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay0zMzg=",
+      "title": "俺の妹がこんなに可愛いわけがない",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTQ4",
+          "title": "俺が妹と恋をするわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ5",
+          "title": "俺が妹とオフ会に行くわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUw",
+          "title": "俺の妹がこんなに可愛いわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUx",
+          "title": "俺の妹が夏コミとか行くわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUy",
+          "title": "俺の妹の親友がこんなに××なわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTUz",
+          "title": "俺の幼馴染がこんなに可愛いわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU0",
+          "title": "俺の妹がこんなに小説家なわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU1",
+          "title": "俺の妹がこんなにアニメ化なわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU2",
+          "title": "俺の妹がこんなにエロゲー三昧なわけがない",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU3",
+          "title": "俺の妹がこんなにコスプレなわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU4",
+          "title": "俺の妹がこんなにメイドなわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTU5",
+          "title": "俺の妹の人生相談がこれで終わるわけがない GOOD END",
+          "numberText": "第12話 (GOOD END)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYw",
+          "title": "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+          "numberText": "第12話 (TRUE ROUTE)"
+        },
+        {
+          "id": "RXBpc29kZS02NTYx",
+          "title": "俺の後輩がこんなに腐ってるわけがない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYy",
+          "title": "俺の後輩がこんなに可愛いわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTYz",
+          "title": "俺の妹がこれで最終回なわけがない",
+          "numberText": "第15話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    },
+    {
+      "id": "V29yay0zMzk=",
+      "title": "俺の妹がこんなに可愛いわけがない。",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS02NTMy",
+          "title": "俺の妹が再び帰ってくるわけがない",
+          "numberText": "第1話"
+        },
+        {
+          "id": "RXBpc29kZS02NTMz",
+          "title": "信じて送り出したお兄さんが携帯美少女ゲームにドハマリして セクハラしてくるようになるわけがない",
+          "numberText": "第2話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM0",
+          "title": "俺の友達が眼鏡を外すわけがない",
+          "numberText": "第3話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM1",
+          "title": "俺の妹のライバルが来日するわけがない",
+          "numberText": "第4話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM2",
+          "title": "俺が妹の彼氏なわけがないし、俺の妹に彼氏がいるわけがない",
+          "numberText": "第5話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM3",
+          "title": "俺の妹が家に彼氏をつれてくるわけがない",
+          "numberText": "第6話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM4",
+          "title": "俺が後輩と恋人同士になるわけがない",
+          "numberText": "第7話"
+        },
+        {
+          "id": "RXBpc29kZS02NTM5",
+          "title": "俺が後輩とひと夏の思い出を作るわけがない",
+          "numberText": "第8話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQw",
+          "title": "俺の妹がこんなに可愛いわけがない!",
+          "numberText": "第9話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQx",
+          "title": "俺の妹がウエディングドレスを着るわけがない",
+          "numberText": "第10話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQy",
+          "title": "一人暮らしの兄貴の部屋に妹たちが押しかけるわけがない",
+          "numberText": "第11話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQz",
+          "title": "マジ天使すぎるあやせたんが一人暮らしの俺んちに降臨するわけがない",
+          "numberText": "第12話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ0",
+          "title": "妹（あたし）が兄（アイツ）に恋なんてするわけない",
+          "numberText": "第13話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ1",
+          "title": "俺が彼女に告白なんてするわけがない",
+          "numberText": "第14話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ2",
+          "title": "俺の妹がこんなに可愛い",
+          "numberText": "第15話"
+        },
+        {
+          "id": "RXBpc29kZS02NTQ3",
+          "title": "俺の妹がこんなに可愛いわけがない。",
+          "numberText": "第16話"
+        }
+      ],
+      "seriesList": [
+        "俺の妹がこんなに可愛いわけがない"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/8676__ヲタクに恋は難しいOAD「社員旅行と願いごと」.json
+++ b/packages/annict/src/fixture-test/fixtures/8676__ヲタクに恋は難しいOAD「社員旅行と願いごと」.json
@@ -1,0 +1,124 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T11:09:19.942Z"
+  },
+  "input": {
+    "params": {
+      "title": "ヲタクに恋は難しい OAD「社員旅行と願いごと」"
+    },
+    "annictUrl": "https://annict.com/works/8676"
+  },
+  "expected": {
+    "id": "V29yay04Njc2",
+    "title": "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+    "episode": null
+  },
+  "variants": [
+    "ヲタクに恋は難しい"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay04Njc2",
+      "title": "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    },
+    {
+      "id": "V29yay03NzU1",
+      "title": "ヲタクに恋は難しい OAD2「トモダチの距離」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    },
+    {
+      "id": "V29yay02ODc4",
+      "title": "ヲタクに恋は難しい OAD「それは、いきなりおとづれた＝恋」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    },
+    {
+      "id": "V29yay01Mzc2",
+      "title": "ヲタクに恋は難しい",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS05ODgwOQ==",
+          "title": "成海と宏嵩の再会。そして…",
+          "number": 1,
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS05ODk5MQ==",
+          "title": "恋人？始めました",
+          "number": 2,
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS05OTY3Mw==",
+          "title": "即売会とゲーム会",
+          "number": 3,
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS05OTk1MA==",
+          "title": "オトナの恋も難しい？",
+          "number": 4,
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0xMDAxMzI=",
+          "title": "尚哉登場とゲーム会PartII",
+          "number": 5,
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0xMDAyOTE=",
+          "title": "憂鬱なクリスマス",
+          "number": 6,
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA0MTY=",
+          "title": "ネトゲと、それぞれの夜",
+          "number": 7,
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA2MjY=",
+          "title": "苦手な雷と、気になるお年頃",
+          "number": 8,
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA3NjU=",
+          "title": "デートへ行こうよ！",
+          "number": 9,
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5Njc=",
+          "title": "光くん登場とネトゲリベンジ",
+          "number": 10,
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0xMDEwODY=",
+          "title": "ヲタクに恋は難しい",
+          "number": 11,
+          "numberText": "#11"
+        }
+      ],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/fixture-test/fixtures/8676__ヲタクに恋は難しいOAD「社員旅行と願いごと」_.json
+++ b/packages/annict/src/fixture-test/fixtures/8676__ヲタクに恋は難しいOAD「社員旅行と願いごと」_.json
@@ -1,0 +1,128 @@
+{
+  "meta": {
+    "createdAt": "2026-03-07T11:12:25.179Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "ヲタクに恋は難しい OAD「社員旅行と願いごと」",
+      "episodeTitle": ""
+    },
+    "annictUrl": "https://annict.com/works/8676"
+  },
+  "expected": {
+    "id": "V29yay04Njc2",
+    "title": "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+    "episode": null
+  },
+  "variants": [
+    "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+    "ヲタクに恋は難しい OAD3社員旅行と願い事",
+    "ヲタクに恋は難しい",
+    "社員旅行と願い事"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay04Njc2",
+      "title": "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    },
+    {
+      "id": "V29yay03NzU1",
+      "title": "ヲタクに恋は難しい OAD2「トモダチの距離」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    },
+    {
+      "id": "V29yay02ODc4",
+      "title": "ヲタクに恋は難しい OAD「それは、いきなりおとづれた＝恋」",
+      "noEpisodes": true,
+      "episodes": [],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    },
+    {
+      "id": "V29yay01Mzc2",
+      "title": "ヲタクに恋は難しい",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS05ODgwOQ==",
+          "title": "成海と宏嵩の再会。そして…",
+          "number": 1,
+          "numberText": "#1"
+        },
+        {
+          "id": "RXBpc29kZS05ODk5MQ==",
+          "title": "恋人？始めました",
+          "number": 2,
+          "numberText": "#2"
+        },
+        {
+          "id": "RXBpc29kZS05OTY3Mw==",
+          "title": "即売会とゲーム会",
+          "number": 3,
+          "numberText": "#3"
+        },
+        {
+          "id": "RXBpc29kZS05OTk1MA==",
+          "title": "オトナの恋も難しい？",
+          "number": 4,
+          "numberText": "#4"
+        },
+        {
+          "id": "RXBpc29kZS0xMDAxMzI=",
+          "title": "尚哉登場とゲーム会PartII",
+          "number": 5,
+          "numberText": "#5"
+        },
+        {
+          "id": "RXBpc29kZS0xMDAyOTE=",
+          "title": "憂鬱なクリスマス",
+          "number": 6,
+          "numberText": "#6"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA0MTY=",
+          "title": "ネトゲと、それぞれの夜",
+          "number": 7,
+          "numberText": "#7"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA2MjY=",
+          "title": "苦手な雷と、気になるお年頃",
+          "number": 8,
+          "numberText": "#8"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA3NjU=",
+          "title": "デートへ行こうよ！",
+          "number": 9,
+          "numberText": "#9"
+        },
+        {
+          "id": "RXBpc29kZS0xMDA5Njc=",
+          "title": "光くん登場とネトゲリベンジ",
+          "number": 10,
+          "numberText": "#10"
+        },
+        {
+          "id": "RXBpc29kZS0xMDEwODY=",
+          "title": "ヲタクに恋は難しい",
+          "number": 11,
+          "numberText": "#11"
+        }
+      ],
+      "seriesList": [
+        "ヲタクに恋は難しい"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/search.ts
+++ b/packages/annict/src/search.ts
@@ -11,19 +11,8 @@ import {
   findEpisodeByTitleAsNumberText,
 } from "./util/search/find-episode";
 import { applyMapping } from "./util/search/mapping";
+import { buildFullTitle } from "./util/search/title";
 import { variants } from "./util/search/variants";
-
-function buildFullTitle(params: SearchParam): string {
-  if ("title" in params) {
-    return params.title;
-  }
-  if ("episodeNumber" in params) {
-    return [params.workTitle, params.episodeNumber, params.episodeTitle]
-      .filter(Boolean)
-      .join(" ");
-  }
-  return [params.workTitle, params.episodeTitle].filter(Boolean).join(" ");
-}
 
 function isMatchingWorkTitle(
   work: { title: string; seriesList: string[] | undefined },
@@ -206,7 +195,7 @@ export async function search(
     }
 
     // エピソードが見つからなかった場合、フルタイトルで検索
-    const fullTitle = buildFullTitle(params);
+    const fullTitle = buildFullTitle(target);
     const strictWork = works.find(
       (work) => work.noEpisodes && isSameTitle(work.title, fullTitle),
     );
@@ -240,7 +229,7 @@ export async function search(
     }
   }
 
-  const targetFullTitle = buildFullTitle(params);
+  const targetFullTitle = buildFullTitle(target);
 
   // strict マッチ
   for (const work of works) {

--- a/packages/annict/src/search.ts
+++ b/packages/annict/src/search.ts
@@ -10,6 +10,7 @@ import {
   findEpisodeByTitleAndNumberText,
   findEpisodeByTitleAsNumberText,
 } from "./util/search/find-episode";
+import { applyMapping } from "./util/search/mapping";
 import { variants } from "./util/search/variants";
 
 function buildFullTitle(params: SearchParam): string {
@@ -58,7 +59,7 @@ export async function search(
   params: SearchParam,
   token: string,
 ): Promise<SearchResult> {
-  const target = extract(params);
+  const target = applyMapping(extract(params));
   const words = variants(target.workTitle);
   const works = await searchWorks(words, token);
 

--- a/packages/annict/src/types.ts
+++ b/packages/annict/src/types.ts
@@ -61,3 +61,8 @@ export type ExtractedEpisode = {
   numberText: string | undefined;
   title: string | undefined;
 };
+
+export type SearchTarget = {
+  workTitle: string;
+  episode: ExtractedEpisode | undefined;
+};

--- a/packages/annict/src/util/extract/extract.ts
+++ b/packages/annict/src/util/extract/extract.ts
@@ -1,4 +1,4 @@
-import type { ExtractedEpisode, SearchParam } from "../../types";
+import type { ExtractedEpisode, SearchParam, SearchTarget } from "../../types";
 import { episodeNumberMatches } from "../match";
 import { parseNumber } from "./number";
 
@@ -16,10 +16,7 @@ function getMatch(
   }
 }
 
-export function extract(params: SearchParam): {
-  workTitle: string;
-  episode: ExtractedEpisode | undefined;
-} {
+export function extract(params: SearchParam): SearchTarget {
   if ("episodeNumber" in params) {
     const episodeNumber = params.episodeNumber.trim();
     if (!episodeNumber) {

--- a/packages/annict/src/util/search/mapping-rules.ts
+++ b/packages/annict/src/util/search/mapping-rules.ts
@@ -1,0 +1,261 @@
+type EpisodeMappingRule = {
+  episodeTitleFrom: string[];
+  episodeTitleTo: string;
+};
+
+type WorkMappingRule = {
+  workTitleFrom: string[];
+  workTitleTo?: string;
+  episodeMappings?: EpisodeMappingRule[];
+};
+
+export const mappingRules: WorkMappingRule[] = [
+  {
+    workTitleFrom: [
+      "〈物語〉シリーズ セカンドシーズン",
+      "〈物語〉シリーズ セカンドシーズン（第1話～第5話） 猫物語(白)",
+      "〈物語〉シリーズ セカンドシーズン（第7話～第10話） 傾物語",
+      "〈物語〉シリーズ セカンドシーズン（第12話～第15話） 囮物語",
+      "〈物語〉シリーズ セカンドシーズン（第17話～第20話） 鬼物語",
+      "〈物語〉シリーズ セカンドシーズン（第21話～第26話） 恋物語",
+      "〈物語〉シリーズ セカンドシーズン（第27話～第31話） 花物語",
+      "〈物語〉シリーズ セカンドシーズン（第6話・第11話・第16話） 総集編",
+    ],
+    workTitleTo: "＜物語＞シリーズ セカンドシーズン",
+    episodeMappings: [
+      {
+        episodeTitleFrom: [
+          "猫物語(白) 第懇話『つばさタイガー其ノ壹』",
+          "『つばさタイガー 其ノ壹』",
+        ],
+        episodeTitleTo: "猫物語(白) つばさタイガー 其ノ壹",
+      },
+      {
+        episodeTitleFrom: [
+          "猫物語(白) 第懇話『つばさタイガー 其ノ貳』",
+          "『つばさタイガー 其ノ貳』",
+        ],
+        episodeTitleTo: "猫物語(白) つばさタイガー 其ノ貳",
+      },
+      {
+        episodeTitleFrom: [
+          "猫物語(白) 第懇話『つばさタイガー 其ノ參』",
+          "『つばさタイガー 其ノ參』",
+        ],
+        episodeTitleTo: "猫物語(白) つばさタイガー 其ノ參",
+      },
+      {
+        episodeTitleFrom: [
+          "猫物語(白) 第懇話『つばさタイガー 其ノ肆』",
+          "『つばさタイガー 其ノ肆』",
+        ],
+        episodeTitleTo: "猫物語(白) つばさタイガー 其ノ肆",
+      },
+      {
+        episodeTitleFrom: [
+          "猫物語(白) 第懇話『つばさタイガー 其ノ伍』",
+          "『つばさタイガー 其ノ伍』",
+        ],
+        episodeTitleTo: "猫物語(白) つばさタイガー 其ノ伍",
+      },
+      {
+        episodeTitleFrom: ["『総集編I』"],
+        episodeTitleTo: "猫物語(黒) 総集篇I",
+      },
+      {
+        episodeTitleFrom: [
+          "傾物語 第閑話『まよいキョンシー 其ノ壹』",
+          "『まよいキョンシー其ノ壹』",
+        ],
+        episodeTitleTo: "傾物語 まよいキョンシー 其ノ壹",
+      },
+      {
+        episodeTitleFrom: [
+          "傾物語 第閑話『まよいキョンシー 其ノ貳』",
+          "『まよいキョンシー其ノ貳』",
+        ],
+        episodeTitleTo: "傾物語 まよいキョンシー 其ノ貳",
+      },
+      {
+        episodeTitleFrom: [
+          "傾物語 第閑話『まよいキョンシー 其ノ參』",
+          "『まよいキョンシー其ノ參』",
+        ],
+        episodeTitleTo: "傾物語 まよいキョンシー 其ノ參",
+      },
+      {
+        episodeTitleFrom: [
+          "傾物語 第閑話『まよいキョンシー 其ノ肆』",
+          "『まよいキョンシー其ノ肆』",
+        ],
+        episodeTitleTo: "傾物語 まよいキョンシー 其ノ肆",
+      },
+      {
+        episodeTitleFrom: ["『総集編II』"],
+        episodeTitleTo: "化物語 総集篇II",
+      },
+      {
+        episodeTitleFrom: [
+          "囮物語 第乱話『なでこメドゥーサ 其ノ壹』",
+          "『なでこメドゥーサ其ノ壹』",
+        ],
+        episodeTitleTo: "囮物語 なでこメドゥーサ 其ノ壹",
+      },
+      {
+        episodeTitleFrom: [
+          "囮物語 第乱話『なでこメドゥーサ 其ノ貳』",
+          "『なでこメドゥーサ其ノ貳』",
+        ],
+        episodeTitleTo: "囮物語 なでこメドゥーサ 其ノ貳",
+      },
+      {
+        episodeTitleFrom: [
+          "囮物語 第乱話『なでこメドゥーサ 其ノ參』",
+          "『なでこメドゥーサ其ノ參』",
+        ],
+        episodeTitleTo: "囮物語 なでこメドゥーサ 其ノ參",
+      },
+      {
+        episodeTitleFrom: [
+          "囮物語 第乱話『なでこメドゥーサ 其ノ肆』",
+          "『なでこメドゥーサ其ノ肆』",
+        ],
+        episodeTitleTo: "囮物語 なでこメドゥーサ 其ノ肆",
+      },
+      {
+        episodeTitleFrom: ["『総集編III』"],
+        episodeTitleTo: "化物語&偽物語 総集篇III",
+      },
+      {
+        episodeTitleFrom: [
+          "鬼物語 第忍話『しのぶタイム 其ノ壹』",
+          "『しのぶタイム 其ノ壹』",
+        ],
+        episodeTitleTo: "鬼物語 しのぶタイム 其ノ壹",
+      },
+      {
+        episodeTitleFrom: [
+          "鬼物語 第忍話『しのぶタイム 其ノ貳』",
+          "『しのぶタイム 其ノ貳』",
+        ],
+        episodeTitleTo: "鬼物語 しのぶタイム 其ノ貳",
+      },
+      {
+        episodeTitleFrom: [
+          "鬼物語 第忍話『しのぶタイム 其ノ參』",
+          "『しのぶタイム 其ノ參』",
+        ],
+        episodeTitleTo: "鬼物語 しのぶタイム 其ノ參",
+      },
+      {
+        episodeTitleFrom: [
+          "鬼物語 第忍話『しのぶタイム 其ノ肆』",
+          "『しのぶタイム 其ノ肆』",
+        ],
+        episodeTitleTo: "鬼物語 しのぶタイム 其ノ肆",
+      },
+      {
+        episodeTitleFrom: [
+          "恋物語 第恋話『ひたぎエンド 其ノ壹』",
+          "『ひたぎエンド 其ノ壹』",
+        ],
+        episodeTitleTo: "恋物語 ひたぎエンド 其ノ壹",
+      },
+      {
+        episodeTitleFrom: [
+          "恋物語 第恋話『ひたぎエンド 其ノ貳』",
+          "『ひたぎエンド 其ノ貳』",
+        ],
+        episodeTitleTo: "恋物語 ひたぎエンド 其ノ貳",
+      },
+      {
+        episodeTitleFrom: [
+          "恋物語 第恋話『ひたぎエンド 其ノ參』",
+          "『ひたぎエンド 其ノ參』",
+        ],
+        episodeTitleTo: "恋物語 ひたぎエンド 其ノ參",
+      },
+      {
+        episodeTitleFrom: [
+          "恋物語 第恋話『ひたぎエンド 其ノ肆』",
+          "『ひたぎエンド 其ノ肆』",
+        ],
+        episodeTitleTo: "恋物語 ひたぎエンド 其ノ肆",
+      },
+      {
+        episodeTitleFrom: [
+          "恋物語 第恋話『ひたぎエンド 其ノ伍』",
+          "『ひたぎエンド 其ノ伍』",
+        ],
+        episodeTitleTo: "恋物語 ひたぎエンド 其ノ伍",
+      },
+      {
+        episodeTitleFrom: [
+          "恋物語 第恋話『ひたぎエンド 其ノ陸』",
+          "『ひたぎエンド 其ノ陸』",
+        ],
+        episodeTitleTo: "恋物語 ひたぎエンド 其ノ陸",
+      },
+      {
+        episodeTitleFrom: [
+          "花物語 第変話『するがデビル 其ノ壹』",
+          "『するがデビル 其ノ壹』",
+        ],
+        episodeTitleTo: "花物語 するがデビル 其ノ壹",
+      },
+      {
+        episodeTitleFrom: [
+          "花物語 第変話『するがデビル 其ノ貳』",
+          "『するがデビル 其ノ貳』",
+        ],
+        episodeTitleTo: "花物語 するがデビル 其ノ貳",
+      },
+      {
+        episodeTitleFrom: [
+          "花物語 第変話『するがデビル 其ノ參』",
+          "『するがデビル 其ノ參』",
+        ],
+        episodeTitleTo: "花物語 するがデビル 其ノ參",
+      },
+      {
+        episodeTitleFrom: [
+          "花物語 第変話『するがデビル 其ノ肆』",
+          "『するがデビル 其ノ肆』",
+        ],
+        episodeTitleTo: "花物語 するがデビル 其ノ肆",
+      },
+      {
+        episodeTitleFrom: [
+          "花物語 第変話『するがデビル 其ノ伍』",
+          "『するがデビル 其ノ伍』",
+        ],
+        episodeTitleTo: "花物語 するがデビル 其ノ伍",
+      },
+    ],
+  },
+  {
+    workTitleFrom: ["劇場版CLANNAD"],
+    workTitleTo: "劇場版 CLANNAD -クラナド-",
+  },
+  {
+    workTitleFrom: [
+      "俺の妹がこんなに可愛いわけがない。TV未放送第14話～最終回第16話",
+      "俺の妹がこんなに可愛いわけがない。TV未放送分第14話～最終回第16話",
+    ],
+    workTitleTo: "俺の妹がこんなに可愛いわけがない。",
+  },
+  {
+    workTitleFrom: ["俺の妹がこんなに可愛いわけがない TRUEROUTE"],
+    workTitleTo: "俺の妹がこんなに可愛いわけがない",
+    episodeMappings: [
+      {
+        episodeTitleFrom: ["俺の妹の人生相談がこれで終わるわけがない"],
+        episodeTitleTo: "俺の妹の人生相談がこれで終わるわけがない TRUE ROUTE",
+      },
+    ],
+  },
+  {
+    workTitleFrom: ["映画「小鳥遊六花・改 ～劇場版 中二病でも恋がしたい!～」"],
+    workTitleTo: "小鳥遊六花・改 ～劇場版 中二病でも恋がしたい！～",
+  },
+];

--- a/packages/annict/src/util/search/mapping-rules.ts
+++ b/packages/annict/src/util/search/mapping-rules.ts
@@ -258,4 +258,22 @@ export const mappingRules: WorkMappingRule[] = [
     workTitleFrom: ["映画「小鳥遊六花・改 ～劇場版 中二病でも恋がしたい!～」"],
     workTitleTo: "小鳥遊六花・改 ～劇場版 中二病でも恋がしたい！～",
   },
+  {
+    workTitleFrom: ["ヲタクに恋は難しい OAD"],
+    workTitleTo: "ヲタクに恋は難しい OAD「それは、いきなりおとづれた＝恋」",
+  },
+  {
+    workTitleFrom: [
+      "ヲタクに恋は難しい OAD2",
+      "ヲタクに恋は難しい OAD「トモダチの距離」",
+    ],
+    workTitleTo: "ヲタクに恋は難しい OAD2「トモダチの距離」",
+  },
+  {
+    workTitleFrom: [
+      "ヲタクに恋は難しい OAD3",
+      "ヲタクに恋は難しい OAD「社員旅行と願いごと」",
+    ],
+    workTitleTo: "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+  },
 ];

--- a/packages/annict/src/util/search/mapping.test.ts
+++ b/packages/annict/src/util/search/mapping.test.ts
@@ -1,0 +1,37 @@
+import { applyMapping } from "./mapping";
+
+test("workTitle の直接一致では episode を保持する", () => {
+  const result = applyMapping({
+    workTitle: "ヲタクに恋は難しい OAD「社員旅行と願いごと」",
+    episode: {
+      number: undefined,
+      numberText: undefined,
+      title: "",
+    },
+  });
+
+  expect(result).toEqual({
+    workTitle: "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+    episode: {
+      number: undefined,
+      numberText: undefined,
+      title: "",
+    },
+  });
+});
+
+test("再結合タイトル一致では episode を破棄する", () => {
+  const result = applyMapping({
+    workTitle: "ヲタクに恋は難しい",
+    episode: {
+      number: 500,
+      numberText: "OAD",
+      title: "社員旅行と願いごと",
+    },
+  });
+
+  expect(result).toEqual({
+    workTitle: "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
+    episode: undefined,
+  });
+});

--- a/packages/annict/src/util/search/mapping.ts
+++ b/packages/annict/src/util/search/mapping.ts
@@ -1,6 +1,7 @@
 import type { SearchTarget } from "../../types";
 import { isSameTitle } from "../normalize";
 import { mappingRules } from "./mapping-rules";
+import { buildFullTitle } from "./title";
 
 export function applyMapping(target: SearchTarget): SearchTarget {
   const mapped: SearchTarget = {
@@ -13,7 +14,24 @@ export function applyMapping(target: SearchTarget): SearchTarget {
       isSameTitle(mapped.workTitle, title),
     ),
   );
+
   if (!rule) {
+    if (!mapped.episode) {
+      return mapped;
+    }
+
+    const mergedTitle = buildFullTitle(mapped);
+    const mergedTitleRule = mappingRules.find((candidate) =>
+      candidate.workTitleFrom.some((title) => isSameTitle(mergedTitle, title)),
+    );
+    if (!mergedTitleRule) {
+      return mapped;
+    }
+
+    if (mergedTitleRule.workTitleTo) {
+      mapped.workTitle = mergedTitleRule.workTitleTo;
+    }
+    mapped.episode = undefined;
     return mapped;
   }
 

--- a/packages/annict/src/util/search/mapping.ts
+++ b/packages/annict/src/util/search/mapping.ts
@@ -1,0 +1,52 @@
+import type { SearchTarget } from "../../types";
+import { isSameTitle } from "../normalize";
+import { mappingRules } from "./mapping-rules";
+
+export function applyMapping(target: SearchTarget): SearchTarget {
+  const mapped: SearchTarget = {
+    workTitle: target.workTitle,
+    episode: target.episode ? { ...target.episode } : undefined,
+  };
+
+  const rule = mappingRules.find((candidate) =>
+    candidate.workTitleFrom.some((title) =>
+      isSameTitle(mapped.workTitle, title),
+    ),
+  );
+  if (!rule) {
+    return mapped;
+  }
+
+  // workTitle変換
+  if (rule.workTitleTo) {
+    mapped.workTitle = rule.workTitleTo;
+  }
+
+  const episodeMappings = rule.episodeMappings;
+  if (!episodeMappings) {
+    return mapped;
+  }
+
+  if (!mapped.episode) {
+    return mapped;
+  }
+
+  const targetEpisodeTitle = mapped.episode.title;
+  if (!targetEpisodeTitle) {
+    return mapped;
+  }
+
+  // episodeTitle変換
+  for (const episodeMapping of episodeMappings) {
+    if (
+      episodeMapping.episodeTitleFrom.some((title) =>
+        isSameTitle(targetEpisodeTitle, title),
+      )
+    ) {
+      mapped.episode.title = episodeMapping.episodeTitleTo;
+      return mapped;
+    }
+  }
+
+  return mapped;
+}

--- a/packages/annict/src/util/search/title.test.ts
+++ b/packages/annict/src/util/search/title.test.ts
@@ -1,0 +1,51 @@
+import { buildFullTitle } from "./title";
+
+describe("buildFullTitle", () => {
+  test("episode がない場合は workTitle のみを返す", () => {
+    const result = buildFullTitle({
+      workTitle: "響け！ユーフォニアム",
+      episode: undefined,
+    });
+
+    expect(result).toBe("響け！ユーフォニアム");
+  });
+
+  test("workTitle, numberText, title を結合して返す", () => {
+    const result = buildFullTitle({
+      workTitle: "もめんたりー・リリィ",
+      episode: {
+        number: 14,
+        numberText: "第14話",
+        title: "続いていく割烹、割烹！",
+      },
+    });
+
+    expect(result).toBe("もめんたりー・リリィ 第14話 続いていく割烹、割烹！");
+  });
+
+  test("numberText と title の前後空白は trim される", () => {
+    const result = buildFullTitle({
+      workTitle: "ヲタクに恋は難しい",
+      episode: {
+        number: undefined,
+        numberText: "  OAD  ",
+        title: "  社員旅行と願いごと  ",
+      },
+    });
+
+    expect(result).toBe("ヲタクに恋は難しい OAD 社員旅行と願いごと");
+  });
+
+  test("numberText と title が空文字の場合は workTitle のみを返す", () => {
+    const result = buildFullTitle({
+      workTitle: "響け！ユーフォニアム",
+      episode: {
+        number: undefined,
+        numberText: "   ",
+        title: "",
+      },
+    });
+
+    expect(result).toBe("響け！ユーフォニアム");
+  });
+});

--- a/packages/annict/src/util/search/title.ts
+++ b/packages/annict/src/util/search/title.ts
@@ -1,0 +1,11 @@
+import type { SearchTarget } from "../../types";
+
+export function buildFullTitle(target: SearchTarget): string {
+  return [
+    target.workTitle,
+    target.episode?.numberText?.trim(),
+    target.episode?.title?.trim(),
+  ]
+    .filter(Boolean)
+    .join(" ");
+}


### PR DESCRIPTION
## Summary

- 作品タイトルやエピソードタイトルの変換ルールを定義する `mapping-rules.ts` を追加
- `applyMapping` 関数を実装し、検索前にタイトルをマッピングルールに基づいて変換する
- `applyMapping` はエピソード結合タイトル（`workTitle + episodeTitle`）でもルールにマッチするよう対応
- `fixture-test/cli.ts` に `applyMapping` を組み込み、フィクスチャ追加時にもマッピングが適用されるよう変更

## Test plan

- 〈物語〉シリーズ セカンドシーズンの各話を配信サービスで視聴し、Annict に正しく記録されることを確認