### PR TITLE
feat: タイトルマッピングを追加

### DIFF
--- a/packages/annict/src/util/match.ts
+++ b/packages/annict/src/util/match.ts
@@ -140,6 +140,7 @@ export const episodeNumberMatches = [
     `復興計画その${num}`,
     `予約${num}`,
     `【MISSION：${num}】`,
+    `【MISSION:${num}】`,
     `${num}日記`,
     `すてっぷ${num}`,
     `特典${num}`,

--- a/packages/annict/src/util/search/mapping-rules.ts
+++ b/packages/annict/src/util/search/mapping-rules.ts
@@ -276,4 +276,26 @@ export const mappingRules: WorkMappingRule[] = [
     ],
     workTitleTo: "ヲタクに恋は難しい OAD3「社員旅行と願い事」",
   },
+  {
+    workTitleFrom: ["ヴァイオレット・エヴァーガーデン 総集編"],
+    workTitleTo: "ヴァイオレット・エヴァーガーデン 特別編集版",
+  },
+  {
+    workTitleFrom: ["ヴァイオレット・エヴァーガーデン Extra Episode"],
+    episodeMappings: [
+      {
+        episodeTitleFrom: ["第1話"],
+        episodeTitleTo: 'きっと"愛"を知る日が来るのだろう',
+      }
+    ]
+  },
+  {
+    workTitleFrom: ["SPY×FAMILY", "SPY×FAMILY SPY×FAMILY"],
+    episodeMappings: [
+      {
+        episodeTitleFrom: ["〈夜帳(とばり)〉／はじめての嫉妬"],
+        episodeTitleTo: "〈夜帷(とばり)〉／はじめての嫉妬"
+      }
+    ]
+  }
 ];

--- a/packages/annict/src/util/search/mapping-rules.ts
+++ b/packages/annict/src/util/search/mapping-rules.ts
@@ -286,16 +286,16 @@ export const mappingRules: WorkMappingRule[] = [
       {
         episodeTitleFrom: ["第1話"],
         episodeTitleTo: 'きっと"愛"を知る日が来るのだろう',
-      }
-    ]
+      },
+    ],
   },
   {
     workTitleFrom: ["SPY×FAMILY", "SPY×FAMILY SPY×FAMILY"],
     episodeMappings: [
       {
         episodeTitleFrom: ["〈夜帳(とばり)〉／はじめての嫉妬"],
-        episodeTitleTo: "〈夜帷(とばり)〉／はじめての嫉妬"
-      }
-    ]
-  }
+        episodeTitleTo: "〈夜帷(とばり)〉／はじめての嫉妬",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
- ヴァイオレット・エヴァーガーデン 特別編集版
- ヴァイオレット・エヴァーガーデン Extra Episode
- SPY×FAMILY のサブタイトル表記ゆれ（夜帳/夜帷）
- 【MISSION:N】形式のエピソード番号マッチパターン