### PR TITLE
fix: 検索用タイトルバリアントの抽出精度を改善

### DIFF
--- a/packages/annict/src/util/search/variants.test.ts
+++ b/packages/annict/src/util/search/variants.test.ts
@@ -2,10 +2,41 @@ import { variants } from "./variants";
 
 test("響け！ユーフォニアム", () => {
   const words = variants("響け！ユーフォニアム");
-  expect(words).toEqual([
-    "響け！ユーフォニアム",
-    "響け!ユーフォニアム",
-    "響け",
-    "ユーフォニアム",
-  ]);
+  expect(words).toEqual(
+    expect.arrayContaining([
+      "響け！ユーフォニアム",
+      "響け!ユーフォニアム",
+      "響け",
+      "ユーフォニアム",
+    ]),
+  );
+});
+
+test("中二病でも恋がしたい！", () => {
+  const words = variants("中二病でも恋がしたい！");
+  expect(words).toEqual(
+    expect.arrayContaining([
+      "中二病でも恋がしたい",
+      "でも",
+      "がしたい",
+      "中二病",
+    ]),
+  );
+});
+
+test("CLANNAD番外編", () => {
+  const words = variants("CLANNAD番外編");
+  expect(words).toEqual(expect.arrayContaining(["CLANNAD", "番外編"]));
+});
+
+test("ignoreList に含まれる語は除外する", () => {
+  const words = variants("よふかしのうたSeason2");
+  expect(words).not.toContain("Season");
+  expect(words).not.toContain("Season2");
+});
+
+test("長音符を含むカタカナを正しく抽出する", () => {
+  const words = variants("ユーフォニアム");
+  expect(words).toContain("ユーフォニアム");
+  expect(words).not.toContain("フォニアム");
 });

--- a/packages/annict/src/util/search/variants.ts
+++ b/packages/annict/src/util/search/variants.ts
@@ -19,11 +19,19 @@ export function variants(title: string): string[] {
     }),
   ];
 
-  const matchList = normalize(title, {
+  const normalizedTitle = normalize(title, {
     remove: { anime: true, movie: true },
-  }).match(
-    /(?:\p{L}{4,}|(?:\p{sc=Han}|\p{sc=Hira}|\p{sc=Kana}){4,}|(?=\p{sc=Han})(?:\p{sc=Han}|\p{sc=Hira}|\p{sc=Kana}){2,})/gu,
-  );
+  });
+  const matchList = [
+    /(?:\p{L}{4,}|(?:\p{sc=Han}|[\p{sc=Hira}ーｰ]|[\p{sc=Kana}ーｰ]){4,}|(?=\p{sc=Han})(?:\p{sc=Han}|[\p{sc=Hira}ーｰ]|[\p{sc=Kana}ーｰ]){2,})/gu,
+    /(?:[\p{sc=Hira}ーｰ]){2,}/gu,
+    /(?:[\p{sc=Kana}ーｰ]){2,}/gu,
+    /\p{sc=Han}{2,}/gu,
+    /(?:\p{sc=Han}|[\p{sc=Hira}ーｰ]|[\p{sc=Kana}ーｰ]){2,}/gu,
+    /\p{Script=Latin}{2,}/gu,
+    /(?:\p{sc=Han}|[\p{sc=Hira}ーｰ]|[\p{sc=Kana}ーｰ]|\p{Script=Latin}){2,}/gu,
+    /\p{L}{2,}/gu,
+  ].flatMap((pattern) => normalizedTitle.match(pattern) ?? []);
   const ignoreList = [
     "season",
     "シーズン",
@@ -33,9 +41,9 @@ export function variants(title: string): string[] {
     "後編",
     "物語",
   ];
-  if (matchList) {
-    words.push(...matchList.filter((word) => !ignoreList.includes(word)));
-  }
+  words.push(
+    ...matchList.filter((word) => !ignoreList.includes(word.toLowerCase())),
+  );
 
   return [...new Set(words)];
 }


### PR DESCRIPTION
## 概要

Annict APIの検索で使う \ariants()\ のタイトル分割ロジックを改善し、検索候補の抽出精度を上げた。

## 変更内容

- \\p{sc=Han}\ などで文字種別ごとに分割したパターンを追加
- 長音符（ー）を含むカタカナ・ひらがなを正しく抽出
- ignoreList の除外判定を、大文字小文字を区別しない比較に変更（例: \Season\）
- 上記に対応するテストケースを追加