### PR TITLE
feat: target.episode.titleにworkTitleが含まれるケースに対応

### DIFF
--- a/packages/annict/src/fixture-test/fixtures/4792-76045__ReLIFE_ReLIFEreport1海崎新太(27)無職.json
+++ b/packages/annict/src/fixture-test/fixtures/4792-76045__ReLIFE_ReLIFEreport1海崎新太(27)無職.json
@@ -1,0 +1,149 @@
+{
+  "meta": {
+    "createdAt": "2026-06-17T17:21:50.098Z"
+  },
+  "input": {
+    "params": {
+      "workTitle": "ReLIFE",
+      "episodeTitle": "ReLIFE report1 海崎新太(27)無職"
+    },
+    "annictUrl": "https://annict.com/works/4792/episodes/76045"
+  },
+  "expected": {
+    "id": "V29yay00Nzky",
+    "title": "ReLIFE",
+    "episode": {
+      "id": "RXBpc29kZS03NjA0NQ==",
+      "title": "海崎新太(27)無職",
+      "number": 1,
+      "numberText": "report 1"
+    }
+  },
+  "variants": [
+    "ReLIFE"
+  ],
+  "candidateWorks": [
+    {
+      "id": "V29yay01NzI2",
+      "title": "ReLIFE 完結編",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS05ODgxMg==",
+          "title": "Seed",
+          "number": 14,
+          "numberText": "Report14"
+        },
+        {
+          "id": "RXBpc29kZS05ODgxMw==",
+          "title": "Need",
+          "number": 15,
+          "numberText": "Report15"
+        },
+        {
+          "id": "RXBpc29kZS05ODgxNA==",
+          "title": "Date",
+          "number": 16,
+          "numberText": "Report16"
+        },
+        {
+          "id": "RXBpc29kZS05ODgxNQ==",
+          "title": "Life",
+          "number": 17,
+          "numberText": "Report17"
+        }
+      ],
+      "seriesList": [
+        "ReLIFE"
+      ]
+    },
+    {
+      "id": "V29yay00Nzky",
+      "title": "ReLIFE",
+      "noEpisodes": false,
+      "episodes": [
+        {
+          "id": "RXBpc29kZS03NjA0NQ==",
+          "title": "海崎新太(27)無職",
+          "number": 1,
+          "numberText": "report 1"
+        },
+        {
+          "id": "RXBpc29kZS03NjEzOQ==",
+          "title": "コミュニケーション能力0点",
+          "number": 2,
+          "numberText": "report 2"
+        },
+        {
+          "id": "RXBpc29kZS03NjIzMQ==",
+          "title": "オッサンなんですから",
+          "number": 3,
+          "numberText": "report 3"
+        },
+        {
+          "id": "RXBpc29kZS03NjM4OQ==",
+          "title": "堕ちる",
+          "number": 4,
+          "numberText": "report 4"
+        },
+        {
+          "id": "RXBpc29kZS03NjU2Nw==",
+          "title": "オーバーラップ",
+          "number": 5,
+          "numberText": "report 5"
+        },
+        {
+          "id": "RXBpc29kZS03NjYzNA==",
+          "title": "初めましてじゃないんだよ",
+          "number": 6,
+          "numberText": "report 6"
+        },
+        {
+          "id": "RXBpc29kZS03NjYzNQ==",
+          "title": "被験者001→002",
+          "number": 7,
+          "numberText": "report 7"
+        },
+        {
+          "id": "RXBpc29kZS03NjYzNg==",
+          "title": "亀裂",
+          "number": 8,
+          "numberText": "report 8"
+        },
+        {
+          "id": "RXBpc29kZS03NjYzNw==",
+          "title": "リベンジ",
+          "number": 9,
+          "numberText": "report 9"
+        },
+        {
+          "id": "RXBpc29kZS03NjYzOA==",
+          "title": "みんなのワガママ",
+          "number": 10,
+          "numberText": "report 10"
+        },
+        {
+          "id": "RXBpc29kZS03NjYzOQ==",
+          "title": "過去トリップ",
+          "number": 11,
+          "numberText": "report 11"
+        },
+        {
+          "id": "RXBpc29kZS03NjY0MA==",
+          "title": "ダブルパニック",
+          "number": 12,
+          "numberText": "report 12"
+        },
+        {
+          "id": "RXBpc29kZS03NjY0MQ==",
+          "title": "告白",
+          "number": 13,
+          "numberText": "report 13"
+        }
+      ],
+      "seriesList": [
+        "ReLIFE"
+      ]
+    }
+  ]
+}

--- a/packages/annict/src/search.test.ts
+++ b/packages/annict/src/search.test.ts
@@ -433,6 +433,43 @@ describe("workTitle & episodeTitle", () => {
     );
     expect(result?.episode?.id).toEqual("RXBpc29kZS03NzU4Nw==");
   });
+
+  test("episodeTitle に作品名が含まれる場合", async () => {
+    const relifeMock: Work[] = [
+      {
+        id: "V29yay00Nzky",
+        title: "ReLIFE",
+        noEpisodes: false,
+        episodes: [
+          {
+            id: "RXBpc29kZS03NjA0NQ==",
+            title: "海崎新太(27)無職",
+            number: 1,
+            numberText: "report 1",
+          },
+        ],
+        seriesList: ["ReLIFE"],
+      },
+    ];
+    vi.mocked(searchWorks).mockResolvedValueOnce(relifeMock);
+    const result = await search(
+      {
+        workTitle: "ReLIFE",
+        episodeTitle: "ReLIFE report1 海崎新太(27)無職",
+      },
+      "token",
+    );
+    expect(result).toEqual({
+      id: "V29yay00Nzky",
+      title: "ReLIFE",
+      episode: {
+        id: "RXBpc29kZS03NjA0NQ==",
+        title: "海崎新太(27)無職",
+        number: 1,
+        numberText: "report 1",
+      },
+    });
+  });
 });
 
 describe("title", () => {

--- a/packages/annict/src/search.ts
+++ b/packages/annict/src/search.ts
@@ -9,6 +9,7 @@ import {
   findEpisodeByTitle,
   findEpisodeByTitleAndNumberText,
   findEpisodeByTitleAsNumberText,
+  findEpisodeByTitleWithWorkTitle,
 } from "./util/search/find-episode";
 import { applyMapping } from "./util/search/mapping";
 import { buildFullTitle } from "./util/search/title";
@@ -76,7 +77,8 @@ export async function search(
     const episode =
       findEpisodeByTitle(work.episodes, target.episode) ??
       findEpisodeByNumberText(work.episodes, target.episode) ??
-      findEpisodeByTitleAsNumberText(work.episodes, target.episode);
+      findEpisodeByTitleAsNumberText(work.episodes, target.episode) ??
+      findEpisodeByTitleWithWorkTitle(work, work.episodes, target.episode);
     if (episode) {
       return {
         id: work.id,
@@ -100,7 +102,15 @@ export async function search(
       const episode =
         findEpisodeByTitle(weakMatchWork.episodes, target.episode) ??
         findEpisodeByNumberText(weakMatchWork.episodes, target.episode) ??
-        findEpisodeByTitleAsNumberText(weakMatchWork.episodes, target.episode);
+        findEpisodeByTitleAsNumberText(
+          weakMatchWork.episodes,
+          target.episode,
+        ) ??
+        findEpisodeByTitleWithWorkTitle(
+          weakMatchWork,
+          weakMatchWork.episodes,
+          target.episode,
+        );
       if (episode) {
         return { id: weakMatchWork.id, title: weakMatchWork.title, episode };
       }

--- a/packages/annict/src/util/search/find-episode.test.ts
+++ b/packages/annict/src/util/search/find-episode.test.ts
@@ -5,6 +5,7 @@ import {
   findEpisodeByTitle,
   findEpisodeByTitleAndNumberText,
   findEpisodeByTitleAsNumberText,
+  findEpisodeByTitleWithWorkTitle,
 } from "./find-episode";
 
 const episodes = [
@@ -463,6 +464,105 @@ describe("findEpisodeByTitleAsNumberText", () => {
       number: undefined,
     };
     expect(findEpisodeByTitleAsNumberText(noNumberText, target)?.id).toEqual(
+      undefined,
+    );
+  });
+});
+
+describe("findEpisodeByTitleWithWorkTitle", () => {
+  const work = { title: "響け！ユーフォニアム", seriesList: undefined };
+
+  test("workTitle + episode.title が一致する場合", () => {
+    const target = {
+      title: "響け！ユーフォニアム ようこそハイスクール",
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(findEpisodeByTitleWithWorkTitle(work, episodes, target)?.id).toEqual(
+      "RXBpc29kZS0xODM1Mg==",
+    );
+  });
+
+  test("workTitle + numberText + episode.title が一致する場合", () => {
+    const relifeWork = { title: "ReLIFE", seriesList: ["ReLIFE"] };
+    const relifeEpisodes = [
+      {
+        id: "RXBpc29kZS03NjA0NQ==",
+        title: "海崎新太(27)無職",
+        number: 1,
+        numberText: "report 1",
+      },
+    ];
+    const target = {
+      title: "ReLIFE report1 海崎新太(27)無職",
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(
+      findEpisodeByTitleWithWorkTitle(relifeWork, relifeEpisodes, target)?.id,
+    ).toEqual("RXBpc29kZS03NjA0NQ==");
+  });
+
+  test("series + workTitle を使った複合タイトルでも一致する", () => {
+    const seriesWork = {
+      title: "アリシゼーション",
+      seriesList: ["ソードアート・オンライン"],
+    };
+    const target = {
+      title: "ソードアート・オンライン アリシゼーション 第1話 サブタイトル",
+      numberText: undefined,
+      number: undefined,
+    };
+    const seriesEpisodes = [
+      {
+        id: "ep1",
+        title: "サブタイトル",
+        number: 1,
+        numberText: "第1話",
+      },
+    ];
+    expect(
+      findEpisodeByTitleWithWorkTitle(seriesWork, seriesEpisodes, target)?.id,
+    ).toEqual("ep1");
+  });
+
+  test("target.titleがundefinedの場合はundefinedを返す", () => {
+    const target = {
+      title: undefined,
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(findEpisodeByTitleWithWorkTitle(work, episodes, target)?.id).toEqual(
+      undefined,
+    );
+  });
+
+  test("episode.titleとnumberTextがundefinedの場合は作品タイトル単体で一致させない", () => {
+    const target = {
+      title: "響け！ユーフォニアム",
+      numberText: undefined,
+      number: undefined,
+    };
+    const episodesWithoutTitle = [
+      {
+        id: "ep1",
+        title: undefined,
+        number: 1,
+        numberText: undefined,
+      },
+    ];
+    expect(
+      findEpisodeByTitleWithWorkTitle(work, episodesWithoutTitle, target)?.id,
+    ).toEqual(undefined);
+  });
+
+  test("一致しない場合はundefinedを返す", () => {
+    const target = {
+      title: "ようこそハイスクール",
+      numberText: undefined,
+      number: undefined,
+    };
+    expect(findEpisodeByTitleWithWorkTitle(work, episodes, target)?.id).toEqual(
       undefined,
     );
   });

--- a/packages/annict/src/util/search/find-episode.ts
+++ b/packages/annict/src/util/search/find-episode.ts
@@ -89,6 +89,42 @@ export function findEpisodeByTitleAsNumberText(
   );
 }
 
+// target.episode.title に work.title が含まれているケース
+export function findEpisodeByTitleWithWorkTitle(
+  work: { title: string; seriesList?: string[] },
+  episodes: Episode[],
+  target: ExtractedEpisode,
+): Episode | undefined {
+  const title = target.title;
+  if (!title) return undefined;
+
+  const workTitles = [
+    work.title,
+    ...(work.seriesList?.map((series) => `${series} ${work.title}`) ?? []),
+  ];
+
+  return findWithStrictOrWeak(episodes, (ep, weak) => {
+    const numberText = ep.numberText?.trim();
+    const episodeTitle = ep.title?.trim();
+
+    return workTitles.some((workTitle) => {
+      if (numberText && episodeTitle) {
+        const withNumber = [workTitle, numberText, episodeTitle].join(" ");
+        if (isSameTitle(withNumber, title, weak)) {
+          return true;
+        }
+      }
+      if (episodeTitle) {
+        const withoutNumber = [workTitle, episodeTitle].join(" ");
+        if (isSameTitle(withoutNumber, title, weak)) {
+          return true;
+        }
+      }
+      return false;
+    });
+  });
+}
+
 // 「」内の文字列を抽出する
 function extractBracketContent(str: string): string | undefined {
   return str.match(/「([^」]+)」/)?.[1];


### PR DESCRIPTION
## 概要
配信サービスのエピソードタイトルに作品名が含まれる場合に、Annictのエピソードを正しく特定できるようにする。

## 変更内容

- `findEpisodeByTitleWithWorkTitle` を追加
- workTitle + episodeNumberTitle + episodeTitle、workTitle + episodeTitleで一致判定
- シリーズ名 + 作品名の複合タイトルにも対応
- 対応するテストを追加